### PR TITLE
Item Use Fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -253,6 +253,9 @@ for i=1, 6 do
     RegisterCommand('slot' .. i,function()
         QBCore.Functions.GetPlayerData(function(PlayerData)
             if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
+                if i == 6 then 
+                    i = MaxInventorySlots
+                end
                 TriggerServerEvent("inventory:server:UseItemSlot", i)
             end
         end)


### PR DESCRIPTION
This fixes the bug which would make it so instead of using the hotkey 6 slot it used the next slot after hotkey 5. Now it will use slot 41 which is binded for hotkey 6