### PR TITLE
Fix inventory spam opening/closing on key hold

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -112,7 +112,7 @@ end)
 
 -- Inventory Main Thread
 RegisterCommand('inventory', function()
-    if not isCrafting then
+    if not isCrafting and not inInventory then
         QBCore.Functions.GetPlayerData(function(PlayerData)
             if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
                 local ped = PlayerPedId()

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -20,6 +20,7 @@ var IsDragging = false;
 
 $(document).on('keydown', function() {
     switch(event.keyCode) {
+        if (event.repeat) { return }
         case 27: // ESC
             Inventory.Close();
             break;

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -19,8 +19,8 @@ var selectedItem = null;
 var IsDragging = false;
 
 $(document).on('keydown', function() {
+    if (event.repeat) { return }
     switch(event.keyCode) {
-        if (event.repeat) { return }
         case 27: // ESC
             Inventory.Close();
             break;


### PR DESCRIPTION
This change prevents the inventory spam opening and closing when holding down the inventory key (default `TAB`)

It will check if the key is being held down in the `keydown` event using the `event.repeat` property

**Current behaviour**
_Press and hold_ -> Open / close inventory endlessly until key is released, then 50/50 chance the inventory is open or closed (depending on if lua or js last captured the keypress)

**Fixed behaviour**
_Press and hold_ -> Open inventory
_Press_ -> Close inventory