### PR TITLE
Duping fix

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -23,7 +23,7 @@ RegisterServerEvent("inventory:server:combineItem")
 AddEventHandler('inventory:server:combineItem', function(item, fromItem, toItem)
 	local src = source
 	local ply = QBCore.Functions.GetPlayer(src)
-	if Player.Functions.GetItemByName(toItem) and Player.Functions.GetItemByName(fromItem) then	
+	if Player.Functions.GetItemByName(toItem) ~= nil and Player.Functions.GetItemByName(fromItem) ~= nil then	
 		ply.Functions.RemoveItem(toItem, 1)
 		ply.Functions.RemoveItem(fromItem, 1)
 		ply.Functions.AddItem(item, 1)

--- a/server/main.lua
+++ b/server/main.lua
@@ -23,10 +23,13 @@ RegisterServerEvent("inventory:server:combineItem")
 AddEventHandler('inventory:server:combineItem', function(item, fromItem, toItem)
 	local src = source
 	local ply = QBCore.Functions.GetPlayer(src)
-
-	ply.Functions.AddItem(item, 1)
-	ply.Functions.RemoveItem(fromItem, 1)
-	ply.Functions.RemoveItem(toItem, 1)
+	if Player.Functions.GetItemByName(toItem) and Player.Functions.GetItemByName(fromItem) then	
+		ply.Functions.RemoveItem(toItem, 1)
+		ply.Functions.RemoveItem(fromItem, 1)
+		ply.Functions.AddItem(item, 1)
+	else 
+		TriggerClientEvent("QBCore:Notify", src, "You can't do that from trunk/glovebox/stash")
+	end 
 end)
 
 RegisterServerEvent("inventory:server:CraftItems")


### PR DESCRIPTION
Checks if you have the items on you before combining as combining from Trunks / Gloveboxes / Stashes causes big dupe exploitation