### PR TITLE
Inheritance of translation

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -5,7 +5,9 @@ description 'QB-Inventory'
 version '1.0.0'
 
 shared_scripts {
+	'@qb-core/shared/locale.lua',
 	'config.lua',
+	'@qb-weapons/locales/en.lua',
 	'@qb-weapons/config.lua'
 }
 


### PR DESCRIPTION
Enables inheritance of translations from QB-Weapons.
Is needed to solve issue 73 in QB-Weapons. Needs PR 78 of QB-Weapons.