### PR TITLE
Fix for labels

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -56,9 +56,11 @@ local function FormatWeaponAttachments(itemdata)
             if WeaponAttachments[itemdata.name] ~= nil then
                 for key, value in pairs(WeaponAttachments[itemdata.name]) do
                     if value.component == v.component then
+                        item = value.item
                         attachments[#attachments+1] = {
                             attachment = key,
-                            label = value.label
+                            label = QBCore.Shared.Items[item].label
+                            --label = value.label
                         }
                     end
                 end
@@ -67,7 +69,6 @@ local function FormatWeaponAttachments(itemdata)
     end
     return attachments
 end
-
 
 local function IsBackEngine(vehModel)
     if BackEngineVehicles[vehModel] then return true end
@@ -587,7 +588,7 @@ RegisterCommand('inventory', function()
                     elseif vehicleClass == 12 then
                         maxweight = 120000
                         slots = 35
-		            elseif vehicleClass == 13 then
+                    elseif vehicleClass == 13 then
                         maxweight = 0
                         slots = 0
                     elseif vehicleClass == 14 then
@@ -681,6 +682,7 @@ end)
 RegisterNUICallback('RemoveAttachment', function(data, cb)
     local ped = PlayerPedId()
     local WeaponData = QBCore.Shared.Items[data.WeaponData.name]
+    local label = QBCore.Shared.Items
     local Attachment = WeaponAttachments[WeaponData.name:upper()][data.AttachmentData.attachment]
 
     QBCore.Functions.TriggerCallback('weapons:server:RemoveAttachment', function(NewAttachments)
@@ -690,9 +692,10 @@ RegisterNUICallback('RemoveAttachment', function(data, cb)
             for k, v in pairs(NewAttachments) do
                 for wep, pew in pairs(WeaponAttachments[WeaponData.name:upper()]) do
                     if v.component == pew.component then
+                        item = pew.item
                         Attachies[#Attachies+1] = {
                             attachment = pew.item,
-                            label = pew.label,
+                            label = QBCore.Shared.Items[item].label,
                         }
                     end
                 end


### PR DESCRIPTION
Fix for attachment labels from QBCore.Shared.Items instead of qb-weapons