### PR TITLE
Fix Primary key's and Integer

### DIFF
--- a/qb-inventory.sql
+++ b/qb-inventory.sql
@@ -1,29 +1,29 @@
 CREATE TABLE IF NOT EXISTS `gloveboxitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `plate` varchar(255) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `plate` varchar(255),
   `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   PRIMARY KEY (`plate`),
   KEY `id` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `stashitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `stash` varchar(255) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `stash` varchar(255),
   `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   PRIMARY KEY (`stash`),
   KEY `id` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `trunkitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `plate` varchar(255) DEFAULT NULL,
+  `id` int NOT NULL AUTO_INCREMENT,
+  `plate` varchar(255),
   `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
   PRIMARY KEY (`plate`),
   KEY `id` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
 
 CREATE TABLE IF NOT EXISTS `player_vehicles` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `license` varchar(50) DEFAULT NULL,
   `citizenid` varchar(50) DEFAULT NULL,
   `vehicle` varchar(50) DEFAULT NULL,
@@ -32,17 +32,17 @@ CREATE TABLE IF NOT EXISTS `player_vehicles` (
   `plate` varchar(50) NOT NULL,
   `fakeplate` varchar(50) DEFAULT NULL,
   `garage` varchar(50) DEFAULT NULL,
-  `fuel` int(11) DEFAULT 100,
+  `fuel` int DEFAULT 100,
   `engine` float DEFAULT 1000,
   `body` float DEFAULT 1000,
-  `state` int(11) DEFAULT 1,
-  `depotprice` int(11) NOT NULL DEFAULT 0,
-  `drivingdistance` int(50) DEFAULT NULL,
+  `state` int DEFAULT 1,
+  `depotprice` int NOT NULL DEFAULT 0,
+  `drivingdistance` int DEFAULT NULL,
   `status` text DEFAULT NULL,
-  `balance` int(11) NOT NULL DEFAULT 0,
-  `paymentamount` int(11) NOT NULL DEFAULT 0,
-  `paymentsleft` int(11) NOT NULL DEFAULT 0,
-  `financetime` int(11) NOT NULL DEFAULT 0,
+  `balance` int NOT NULL DEFAULT 0,
+  `paymentamount` int NOT NULL DEFAULT 0,
+  `paymentsleft` int NOT NULL DEFAULT 0,
+  `financetime` int NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `plate` (`plate`),
   KEY `citizenid` (`citizenid`),


### PR DESCRIPTION
A Primary Key can't be NULL, so I have removed the DEFAULT NULL.
Removed Integer display width because it's deprecated and will be removed in a future release.