### PR TITLE
Removed redundant GetClosestVehicle call, passing in already located …

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -75,8 +75,7 @@ local function IsBackEngine(vehModel)
     return false
 end
 
-local function OpenTrunk()
-    local vehicle = QBCore.Functions.GetClosestVehicle()
+local function OpenTrunk(vehicle)
     while (not HasAnimDictLoaded("amb@prop_human_bum_bin@idle_b")) do
         RequestAnimDict("amb@prop_human_bum_bin@idle_b")
         Wait(100)
@@ -613,7 +612,7 @@ RegisterCommand('inventory', function()
                     slots = slots,
                 }
                 TriggerServerEvent("inventory:server:OpenInventory", "trunk", CurrentVehicle, other)
-                OpenTrunk()
+                OpenTrunk(curVeh)
             elseif CurrentGlovebox then
                 TriggerServerEvent("inventory:server:OpenInventory", "glovebox", CurrentGlovebox)
             elseif CurrentDrop then


### PR DESCRIPTION
The call ```local vehicle = QBCore.Functions.GetClosestVehicle()``` is already being made prior to calling OpenTrunk() so rather than call it again just to run an animation to open the trunk, I figure that because we already have the vehicle instance to setup the inventory page, then pass that curVeh variable (which was already being populated) into the OpenTrunk call