### PR TITLE
🔒 [Exploit] Steal money from everyone (Fix)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -15,6 +15,7 @@ local CurrentStash = nil
 local isCrafting = false
 local isHotbar = false
 local itemInfos = {}
+local robbingPlayerId = nil
 
 -- Functions
 
@@ -309,6 +310,7 @@ RegisterNetEvent('inventory:client:requiredItems', function(items, bool)
 end)
 
 RegisterNetEvent('inventory:server:RobPlayer', function(TargetId)
+    robbingPlayerId = TargetId
     SendNUIMessage({
         action = "RobMoney",
         TargetId = TargetId,
@@ -663,6 +665,8 @@ end)
 -- NUI
 
 RegisterNUICallback('RobMoney', function(data)
+    if robbingPlayerId ~= data.TargetId then return end
+    robbingPlayerId = nil
     TriggerServerEvent("police:server:RobPlayer", data.TargetId)
 end)
 


### PR DESCRIPTION
## What is this pull request?
This pull request will fix a **major** vulnerability in the `qb-inventory` resource which allows a hacker to easily steal money from every online player on the server.

## Vulnerability
The vulnerability lies in an unprotected NUI Callback called `RobMoney` which does not double check any data, but instead just forwards the given ID to a server event, which steals all the money from the player.

```lua
RegisterNUICallback('RobMoney', function(data)
    TriggerServerEvent("police:server:RobPlayer", data.TargetId)
end)
```
```lua
RegisterNetEvent('police:server:RobPlayer', function(playerId)
    local src = source
    local Player = QBCore.Functions.GetPlayer(src)
    local SearchedPlayer = QBCore.Functions.GetPlayer(playerId)
    if SearchedPlayer then
        local money = SearchedPlayer.PlayerData.money["cash"]
        Player.Functions.AddMoney("cash", money, "police-player-robbed")
        SearchedPlayer.Functions.RemoveMoney("cash", money, "police-player-robbed")
        TriggerClientEvent('QBCore:Notify', SearchedPlayer.PlayerData.source, Lang:t("info.cash_robbed", {money = money}))
        TriggerClientEvent('QBCore:Notify', Player.PlayerData.source, Lang:t("info.stolen_money", {stolen = money}))
    end
end)
```

\
As we can see here, the before mentioned callback takes the ID we provide it and directly forwards it to the server, which then without any double checks, just removes the money from the player. Since players can craft custom POST packets to trigger NUI Callbacks with any data they want, we can build a very simple script that will loop through all the player IDs and steal the money from either every single person on the server or only from a specific one.

## Solution
To solve this issue, I made a quick fix that upon a legit robbing action *(`police:client:RobPlayer` - triggered through radial menu)* the ID of a target is stored in a variable and once the NUI Callback for stealing the money is called, it checks whether the ID that the callback was provided with matches the one of the player we are currently robbing. If it does not, it means that the NUI Callback received an illegitimate ID.

## Note
I sadly did not manage to fully test whether the robbing of players still works normally after this commit/fix, however since the changes are extremely simple *(only 4 changed lines)* I suppose it should still work perfectly fine. However just in case, I suggest someone tests this version out before merging it live.

Also in the future it may be more secure to somehow implement these security checks on server-side, however due to severity of this issue I believe that this fix is a quickest and simplest way to prevent 95% of hackers from using this vulnerability.