### PR TITLE
fix(ui): Patch bugs with hardware and weapon shops

### DIFF
--- a/html_app/components/PlayerInventory.vue
+++ b/html_app/components/PlayerInventory.vue
@@ -419,7 +419,7 @@ export default {
                 }
                 amount = oldItemSlot.amount;
                 // Handle shift to split into two
-                if (this.splitItem && this.amount > 1) {
+                if (this.splitItem && amount > 1) {
                   amount /= 2;
                 }
             } else if (this.amount < 0) {
@@ -505,7 +505,7 @@ export default {
             }
 
             // Check weight
-            if (this.totalWeight > this.playerInventory.maxweight || this.totalWeightOther > this.openedInventory.maxweight) {
+            if (this.totalWeight > this.playerInventory.maxweight || (this.openedInventory.type != "itemshop" && this.totalWeightOther > this.openedInventory.maxweight)) {
                 /** @todo Send an error warning */
                 Object.assign(this.items, backupItems);
                 return
@@ -594,7 +594,7 @@ export default {
                 return;
             }
 
-            const amount = this.amount;
+            const amount = Math.floor(this.amount);
             if (this.amount > 1) {
                 this.amount = 1;
             }


### PR DESCRIPTION
### 👋 Hey

Some players and dev ask for a patch to the issue happening when you're interacting with an inventory (as hardware shop or weapon shop)!

## 🛠️ Issue

### 🤔 The players issue ?

A player can't pick anything from an armory or a hardware store.

### 💡 The real issue ?

Both armories and hardware shops are setup as `itemshop` in the inventory.
Their weights limit is setup on 150! But the inventory's weight is 1500+! (as you can see below)

![image](https://user-images.githubusercontent.com/27992458/162577163-900eb8ac-f4e6-4815-9882-8d1f451bed68.png)

## ✅ The solution

We do not have a lot of ways to correct this issue...
So I've just disabled the `weightLimit` on inventories with `itemshop`!

## 🧑‍💻 Reviews

Feel free to review, comment, ask any question or test it! I'm available to talk about in on Discord or here.

## 📌 Extras

I've patch the `ShiftLeft` to split item on drop!
And I've add a little security on the switch items to **make sure** that the player is not using a non integer number!

###### ⭐ Take 2 sec to leave a star on the qb-inventory repo and follow me 😎