### PR TITLE
Make inventory containers unselectable with tab pressed

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -27,6 +27,36 @@ body {
 	overflow-x: hidden;
 }
 
+.disableSelection {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
+input { 
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
+input::selection { 
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
 #qbcore-inventory {
 	position: absolute;
 	width: 100%;

--- a/html/ui.html
+++ b/html/ui.html
@@ -28,7 +28,7 @@
             </div>
             <div class="inv-container">
                 <div class="ply-inv-container">
-                    <div class="player-inventory" data-inventory="player"></div>
+                    <div class="player-inventory disableSelection" data-inventory="player"></div>
                 </div>
                 <div class="inv-options">
                     <div class="inv-options-list">
@@ -39,7 +39,7 @@
                     </div>
                 </div>
                 <div class="oth-inv-container">
-                    <div class="other-inventory" data-inventory="other">
+                    <div class="other-inventory disableSelection" data-inventory="other">
                             <!-- auto generated -->
                     </div>
                 </div>


### PR DESCRIPTION
**Describe Pull request**
Removed the ability to cycle through the inventory CSS containers when keeping TAB pressed.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
