### PR TITLE
Inventory fix to major ammo copy glitch

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -461,10 +461,13 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         currentWeapon = weaponName
     else
         TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
-        QBCore.Functions.TriggerCallback("weapon:server:GetWeaponAmmo", function(result)
+        QBCore.Functions.TriggerCallback("weapon:server:GetWeaponAmmo", function(result, name)
             local ammo = tonumber(result)
             if weaponName == "weapon_petrolcan" or weaponName == "weapon_fireextinguisher" then
                 ammo = 4000
+            end
+	    if name ~= weaponName then
+                ammo = 0
             end
             GiveWeaponToPed(ped, GetHashKey(weaponName), 0, false, false)
             SetPedAmmo(ped, GetHashKey(weaponName), ammo)


### PR DESCRIPTION
Suppose you have any loaded gun in slot 1 and a empty gun in slot 2. You just pull up your 1slot gun, shoot few bullet(not necessary) then put it in pocket, then press 1 and 2 at the same time in such a way that the gun at slot 2 comes atlast, and you get ur 1st slot weapon ammo copied to 2nd slot weapon. Try it!
I hope I you understood what i tried to tell!

There are more fixes in qb-weapons