### PR TITLE
Add model dimension calculation

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -552,7 +552,7 @@ RegisterCommand('inventory', function()
                 if vehicle ~= 0 and vehicle ~= nil then
                     local pos = GetEntityCoords(ped)
                     local minimum, maximum = GetModelDimensions(GetEntityModel(vehicle))
-                    local ratio = math.abs(maximum.y/minimum.y)
+                    local ratio = math.abs(minimum.y/maximum.y)
                     local offset = minimum.y - (maximum.y + minimum.y)*ratio
                     local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, offset, 0)
                     if (IsBackEngine(GetEntityModel(vehicle))) then

--- a/client/main.lua
+++ b/client/main.lua
@@ -551,11 +551,14 @@ RegisterCommand('inventory', function()
                 local vehicle = QBCore.Functions.GetClosestVehicle()
                 if vehicle ~= 0 and vehicle ~= nil then
                     local pos = GetEntityCoords(ped)
-                    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, -2.5, 0)
+                    local minimum, maximum = GetModelDimensions(GetEntityModel(vehicle))
+                    local ratio = math.abs(maximum.y/minimum.y)
+                    local offset = minimum.y - (maximum.y + minimum.y)*ratio
+                    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, offset, 0)
                     if (IsBackEngine(GetEntityModel(vehicle))) then
-                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, 2.5, 0)
+                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, math.abs(offset), 0)
                     end
-                    if #(pos - trunkpos) < 2.0 and not IsPedInAnyVehicle(ped) then
+                    if #(pos - trunkpos) < 1.5 and not IsPedInAnyVehicle(ped) then
                         if GetVehicleDoorLockStatus(vehicle) < 2 then
                             CurrentVehicle = QBCore.Functions.GetPlate(vehicle)
                             curVeh = vehicle


### PR DESCRIPTION
**Describe Pull request**
This simply calculated the model dimensions and accurately determines the back/front of vehicle with high accuracy. This also reduces the area to check down from 2.0 down to 1.5 since we are accurately getting this position. This fixes things like the trunk on box trucks being on the side because a set value is set even though every car is different. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No, I run modified base, however this event is unchanged from QB-Inventory.
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
