### PR TITLE
tweak(trunks): Even better finding of trunk pos

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -554,7 +554,7 @@ RegisterCommand('inventory', function()
                     local dimensionMin, dimensionMax = GetModelDimensions(GetEntityModel(vehicle))
 		    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMin.y), 0.0)
                     if (IsBackEngine(GetEntityModel(vehicle))) then
-                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y) + 0.2, 0.0)
+                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y), 0.0)
                     end
                     if #(pos - trunkpos) < 1.5 and not IsPedInAnyVehicle(ped) then
                         if GetVehicleDoorLockStatus(vehicle) < 2 then

--- a/client/main.lua
+++ b/client/main.lua
@@ -551,7 +551,7 @@ RegisterCommand('inventory', function()
                 local vehicle = QBCore.Functions.GetClosestVehicle()
                 if vehicle ~= 0 and vehicle ~= nil then
                     local pos = GetEntityCoords(ped)
-                    local minimum, maximum = GetModelDimensions(GetEntityModel(vehicle))
+                    local dimensionMin, dimensionMax = GetModelDimensions(GetEntityModel(vehicle))
 		    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMin.y), 0.0)
                     if (IsBackEngine(GetEntityModel(vehicle))) then
                         trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y) + 0.2, 0.0)

--- a/client/main.lua
+++ b/client/main.lua
@@ -552,11 +552,9 @@ RegisterCommand('inventory', function()
                 if vehicle ~= 0 and vehicle ~= nil then
                     local pos = GetEntityCoords(ped)
                     local minimum, maximum = GetModelDimensions(GetEntityModel(vehicle))
-                    local ratio = math.abs(minimum.y/maximum.y)
-                    local offset = minimum.y - (maximum.y + minimum.y)*ratio
-                    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, offset, 0)
+		    local trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMin.y), 0.0)
                     if (IsBackEngine(GetEntityModel(vehicle))) then
-                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0, math.abs(offset), 0)
+                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y) + 0.2, 0.0)
                     end
                     if #(pos - trunkpos) < 1.5 and not IsPedInAnyVehicle(ped) then
                         if GetVehicleDoorLockStatus(vehicle) < 2 then


### PR DESCRIPTION
**Describe Pull request**
This is a modification to my first PR that improves the trunks even more. This should be 100% reliable at any model finding the trunk assuming that it is set correctly of front/back in the config. If it is not set correctly the system will still work but the position might be in the back instead of being in the front. 

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No, run a modded core, but not affecting this area.
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes