### PR TITLE
Fixed dupe item bug using decimal quantities

### DIFF
--- a/html/ui.html
+++ b/html/ui.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="inv-options">
                     <div class="inv-options-list">
-                        <input type="number" id="item-amount" class="inv-option-item" min=0 value="0" oninput="validity.valid||(value='');"></input>
+                        <input type="number" id="item-amount" class="inv-option-item" min=1 max="10000" placeholder="Amount" pattern="[0-9]" onfocus="this.value=''" placeholder="" oninput="validity.valid||(value='');"></input>
                         <div class="inv-option-item" id="item-use"><p>USE</p></div>
                         <div class="inv-option-item" id="item-give"><p>GIVE</p></div>
                         <div class="inv-option-item" id="inv-close"><p>CLOSE</p></div>


### PR DESCRIPTION
**Describe Pull request**
If you have an item in your inventory and you change the qty to 0.0000001 or similar, then drop the item, you duplicate the item.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes, we found this originally by a fix lj-inventory put into place on their script, since moving back to qb-inventory we noticed this dupe still exists.
- Does your code fit the style guidelines? Unsure
- Does your PR fit the contribution guidelines? Yes

Not 100% sure if this is the best way to fix it, however it simply stops you from entering a qty starting with 0 and only lets you add numbers 0-9.
