### PR TITLE
fix(server): save usable items to qb-core

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -463,7 +463,7 @@ exports("GetUsableItem", GetUsableItem)
 ---@param itemName string The name of the item to use
 ---@param ... any Arguments for the callback, this will be sent to the callback and can be used to get certain values
 local function UseItem(itemName, ...)
-	local callback = UsableItems[itemName].__cfx_functionReference and UsableItems[itemName] or UsableItems[itemName].cb or UsableItems[itemName].callback
+	local callback = type(UsableItems[itemName]) == 'table' and (rawget(UsableItems[itemName], '__cfx_functionReference') and UsableItems[itemName] or UsableItems[itemName].cb or UsableItems[itemName].callback)
 	if not callback then return end
 	callback(...)
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -463,7 +463,7 @@ exports("GetUsableItem", GetUsableItem)
 ---@param itemName string The name of the item to use
 ---@param ... any Arguments for the callback, this will be sent to the callback and can be used to get certain values
 local function UseItem(itemName, ...)
-	local callback = type(UsableItems[itemName]) == 'function' and UsableItems[itemName] or type(UsableItems[itemName]) == 'table' and (UsableItems[itemName].cb or UsableItems[itemName].callback)
+	local callback = UsableItems[itemName].__cfx_functionReference and UsableItems[itemName] or UsableItems[itemName].cb or UsableItems[itemName].callback
 	if not callback then return end
 	callback(...)
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -445,6 +445,7 @@ exports("HasItem", HasItem)
 ---@param data any
 local function CreateUsableItem(itemName, data)
 	UsableItems[itemName] = data
+	exports['qb-core']:SetUseableItem(itemName, data)
 end
 
 exports("CreateUsableItem", CreateUsableItem)
@@ -462,7 +463,7 @@ exports("GetUsableItem", GetUsableItem)
 ---@param itemName string The name of the item to use
 ---@param ... any Arguments for the callback, this will be sent to the callback and can be used to get certain values
 local function UseItem(itemName, ...)
-	local callback = UsableItems[itemName]
+	local callback = type(UsableItems[itemName]) == 'function' and UsableItems[itemName] or type(UsableItems[itemName]) == 'table' and (UsableItems[itemName].cb or UsableItems[itemName].callback)
 	if not callback then return end
 	callback(...)
 end
@@ -921,7 +922,7 @@ local function AddToGlovebox(plate, slot, otherslot, itemName, amount, info)
 	end
 end
 
----Remove the item from the stash
+---Remove the item from the glovebox
 ---@param plate string Plate of the car to remove the item from
 ---@param slot number Slot to remove the item from
 ---@param itemName string Name of the item to remove
@@ -1126,6 +1127,16 @@ AddEventHandler('onResourceStart', function(resourceName)
 			SetInventory(k, items)
 		end)
 	end
+end)
+
+AddEventHandler('onServerResourceStart', function(resource)
+	if resource ~= GetCurrentResourceName() then return end
+	UsableItems = exports['qb-core']:GetUseableItems()
+end)
+
+AddEventHandler('onServerResourceStop', function(resource)
+	if resource ~= GetCurrentResourceName() then return end
+	exports['qb-core']:SetUseableItems(UsableItems)
 end)
 
 RegisterNetEvent('QBCore:Server:UpdateObject', function()

--- a/server/main.lua
+++ b/server/main.lua
@@ -6,7 +6,6 @@ local Trunks = {}
 local Gloveboxes = {}
 local Stashes = {}
 local ShopItems = {}
-local UsableItems = {}
 
 --#endregion Variables
 
@@ -444,8 +443,7 @@ exports("HasItem", HasItem)
 ---@param itemName string The name of the item to make usable
 ---@param data any
 local function CreateUsableItem(itemName, data)
-	UsableItems[itemName] = data
-	exports['qb-core']:SetUseableItem(itemName, data)
+	QBCore.Functions.CreateUseableItem(itemName, data)
 end
 
 exports("CreateUsableItem", CreateUsableItem)
@@ -454,16 +452,17 @@ exports("CreateUsableItem", CreateUsableItem)
 ---@param itemName string The item to get the data for
 ---@return any usable_item
 local function GetUsableItem(itemName)
-	return UsableItems[itemName]
+	return QBCore.Functions.CanUseItem(itemName)
 end
 
 exports("GetUsableItem", GetUsableItem)
 
----Use an item from the UsableItems table if a callback is present
+---Use an item from the QBCore.UsableItems table if a callback is present
 ---@param itemName string The name of the item to use
 ---@param ... any Arguments for the callback, this will be sent to the callback and can be used to get certain values
 local function UseItem(itemName, ...)
-	local callback = type(UsableItems[itemName]) == 'table' and (rawget(UsableItems[itemName], '__cfx_functionReference') and UsableItems[itemName] or UsableItems[itemName].cb or UsableItems[itemName].callback)
+	local itemData = GetUsableItem(itemName)
+	local callback = type(itemData) == 'table' and (rawget(itemData, '__cfx_functionReference') and itemData or itemData.cb or itemData.callback) or type(itemData) == 'function' and itemData
 	if not callback then return end
 	callback(...)
 end
@@ -1127,16 +1126,6 @@ AddEventHandler('onResourceStart', function(resourceName)
 			SetInventory(k, items)
 		end)
 	end
-end)
-
-AddEventHandler('onServerResourceStart', function(resource)
-	if resource ~= GetCurrentResourceName() then return end
-	UsableItems = exports['qb-core']:GetUseableItems()
-end)
-
-AddEventHandler('onServerResourceStop', function(resource)
-	if resource ~= GetCurrentResourceName() then return end
-	exports['qb-core']:SetUseableItems(UsableItems)
 end)
 
 RegisterNetEvent('QBCore:Server:UpdateObject', function()


### PR DESCRIPTION
**Describe Pull request**
This fixes the deletion of the usable items whenever you restart qb-inventory, this PR is together with https://github.com/qbcore-framework/qb-core/pull/798

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
