### PR TITLE
Default weapon quality `AddItem`

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -169,7 +169,8 @@ local function AddItem(source, item, amount, slot, info)
 
 	if itemInfo['type'] == 'weapon' and not info then
 		info = {
-			serie = tostring(QBCore.Shared.RandomInt(2) .. QBCore.Shared.RandomStr(3) .. QBCore.Shared.RandomInt(1) .. QBCore.Shared.RandomStr(2) .. QBCore.Shared.RandomInt(3) .. QBCore.Shared.RandomStr(4))
+			serie = tostring(QBCore.Shared.RandomInt(2) .. QBCore.Shared.RandomStr(3) .. QBCore.Shared.RandomInt(1) .. QBCore.Shared.RandomStr(2) .. QBCore.Shared.RandomInt(3) .. QBCore.Shared.RandomStr(4)),
+			quality = 100
 		}
 	end
 	if (totalWeight + (itemInfo['weight'] * amount)) <= Config.MaxInventoryWeight then


### PR DESCRIPTION
To fix whatever these guys are trying to do, https://github.com/qbcore-framework/qb-weapons/issues/127 https://github.com/qbcore-framework/qb-weapons/pull/128

This happens because using the [`AddItem`](https://github.com/qbcore-framework/qb-inventory/blob/19baee5a662797b9894057f8440bb5fea16172b8/server/main.lua#L155) function doesn't apply any weapon quality whatsoever by itself. Only a [`serial number`](https://github.com/qbcore-framework/qb-inventory/blob/19baee5a662797b9894057f8440bb5fea16172b8/server/main.lua#L172). This results in the aforementioned error when acquiring weapons through other means besides armory etc. You could easily test this by using the [`GiveItem`](https://github.com/qbcore-framework/qb-inventory/blob/19baee5a662797b9894057f8440bb5fea16172b8/server/main.lua#L2134) command because it applies [`weapon quality`](https://github.com/qbcore-framework/qb-inventory/blob/19baee5a662797b9894057f8440bb5fea16172b8/server/main.lua#L2155-L2158) itself. To save everyone a big headache and to avoid third parties having to make changes to their resources, just bake it in into the default function itself.

Why does this suddenly happen? Who knows. Too many PRs, tried to look but nothing really that points it out. Previously the quality always defaulted to 100 for new weapons but apparently not anymore.

Tested and ready to ship.
![alt text](https://cdn.discordapp.com/avatars/166971354678165505/a_fa101c352fa4ce0482da9a730f6bea9f.gif?size=1024 "ChatDisabled")