### PR TITLE
Remove tab selection cycling between inventory CSS containers

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -37,26 +37,6 @@ body {
     outline: 0;
 }
 
-input { 
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    outline: 0;
-}
-
-input::selection { 
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    outline: 0;
-}
-
 #qbcore-inventory {
 	position: absolute;
 	width: 100%;

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -27,6 +27,36 @@ body {
 	overflow-x: hidden;
 }
 
+.disableSelection {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
+input { 
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
+input::selection { 
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    outline: 0;
+}
+
 #qbcore-inventory {
 	position: absolute;
 	width: 100%;

--- a/html/ui.html
+++ b/html/ui.html
@@ -32,7 +32,7 @@
                 </div>
                 <div class="inv-options">
                     <div class="inv-options-list">
-                        <input type="number" id="item-amount" class="inv-option-item" min=1 max="10000" placeholder="Amount" pattern="[0-9]" onfocus="this.value=''" placeholder="" oninput="validity.valid||(value='');"></input>
+                        <input tabindex="-1" type="number" id="item-amount" class="inv-option-item" min=1 max="10000" placeholder="Amount" pattern="[0-9]" onfocus="this.value=''" placeholder="" oninput="validity.valid||(value='');"></input>
                         <div class="inv-option-item" id="item-use"><p>USE</p></div>
                         <div class="inv-option-item" id="item-give"><p>GIVE</p></div>
                         <div class="inv-option-item" id="inv-close"><p>CLOSE</p></div>

--- a/html/ui.html
+++ b/html/ui.html
@@ -28,7 +28,7 @@
             </div>
             <div class="inv-container">
                 <div class="ply-inv-container">
-                    <div class="player-inventory" data-inventory="player"></div>
+                    <div class="player-inventory disableSelection" data-inventory="player"></div>
                 </div>
                 <div class="inv-options">
                     <div class="inv-options-list">
@@ -39,7 +39,7 @@
                     </div>
                 </div>
                 <div class="oth-inv-container">
-                    <div class="other-inventory" data-inventory="other">
+                    <div class="other-inventory disableSelection" data-inventory="other">
                             <!-- auto generated -->
                     </div>
                 </div>


### PR DESCRIPTION
**Describe Pull request**
This fixes the issue were if you hold TAB a regular selection outline would cycle between inventory, amount and other inventory.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
