### PR TITLE
Fixed issue #335

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -382,6 +382,10 @@ AddEventHandler('onResourceStop', function(name)
     if Config.UseItemDrop then RemoveAllNearbyDrops() end
 end)
 
+RegisterNetEvent("qb-inventory:client:closeinv", function()
+    closeInventory()
+end)
+
 RegisterNetEvent('inventory:client:CheckOpenState', function(type, id, label)
     local name = QBCore.Shared.SplitStr(label, "-")[2]
     if type == "stash" then

--- a/server/main.lua
+++ b/server/main.lua
@@ -1954,6 +1954,7 @@ RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, to
 				if toItemData then
 					toAmount = tonumber(toAmount) and tonumber(toAmount) or toItemData.amount
 					if toItemData.name ~= fromItemData.name then
+						itemInfo = QBCore.Shared.Items[toItemData.name:lower()]
 						RemoveItem(src, toItemData.name, toAmount, toSlot)
 						AddToDrop(fromInventory, toSlot, itemInfo["name"], toAmount, toItemData.info)
 						if itemInfo["name"] == "radio" then

--- a/server/main.lua
+++ b/server/main.lua
@@ -1414,6 +1414,7 @@ RegisterNetEvent('inventory:server:OpenInventory', function(name, id, other)
 					secondInv.slots = 0
 				end
 			end
+			TriggerClientEvent("qb-inventory:client:closeinv", id)
 			TriggerClientEvent("inventory:client:OpenInventory", src, {}, Player.PlayerData.items, secondInv)
 		else
 			TriggerClientEvent("inventory:client:OpenInventory", src, {}, Player.PlayerData.items)


### PR DESCRIPTION
**Describe Pull request**
Fixed the item doubling bug with rob method, mentioned in the issue #335. I added an event in the client-side to close the inventory and used it in the server-side where the otherplayer inventory opens. So, whenever the rob event is executed, the inventory of other player gets closed automatically and it prevents the duplicating of items.

Issue link - https://github.com/qbcore-framework/qb-inventory/issues/335

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
