### PR TITLE
Fix bug where the wrong item got moved to drop

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -1953,6 +1953,7 @@ RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, to
 				if toItemData then
 					toAmount = tonumber(toAmount) and tonumber(toAmount) or toItemData.amount
 					if toItemData.name ~= fromItemData.name then
+						itemInfo = QBCore.Shared.Items[toItemData.name:lower()]
 						RemoveItem(src, toItemData.name, toAmount, toSlot)
 						AddToDrop(fromInventory, toSlot, itemInfo["name"], toAmount, toItemData.info)
 						if itemInfo["name"] == "radio" then


### PR DESCRIPTION
**Describe Pull request**
This fixes a bug that when an item was supposed to be replaced in a drop with another item from an inventory, the item that got added to the drop was the wrong one, and the item basically got duped.

Fixes #335

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **yes**
- Does your code fit the style guidelines? **yes**
- Does your PR fit the contribution guidelines? **yes**
