### PR TITLE
BUG FIX for main.lua

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -104,7 +104,7 @@ local function GetTotalWeight(items)
 	local weight = 0
     if not items then return 0 end
     for _, item in pairs(items) do
-        weight += item.weight * item.amount
+        weight = weight + (item.weight * item.amount)
     end
     return tonumber(weight)
 end


### PR DESCRIPTION
According to the Lua manual there are no shortcut operators in math.

This needs to be approved so I can put in the fix for the truck driving job inventory system.

The inventory is being saved to a json file so the shops' inventory can be maintained between server restarts.

This is done because the trucking job refills the inventory.

This bug was found and needs to be applied before the shops can be fixed.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
