### PR TITLE
[ENHANCEMENT] Deprecate HasItem callback

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2068,43 +2068,6 @@ QBCore.Functions.CreateCallback('inventory:server:GetCurrentDrops', function(_, 
 	cb(Drops)
 end)
 
---[[
-QBCore.Functions.CreateCallback('QBCore:HasItem', function(source, cb, items, amount)
-	print("^3QBCore:HasItem is deprecated, please use QBCore.Functions.HasItem, it can be used on both server- and client-side and uses the same arguments.^0")
-    local retval = false
-    local Player = QBCore.Functions.GetPlayer(source)
-    if not Player then return cb(false) end
-    local isTable = type(items) == 'table'
-    local isArray = isTable and table.type(items) == 'array' or false
-    local totalItems = #items
-    local count = 0
-    local kvIndex = 2
-    if isTable and not isArray then
-        totalItems = 0
-        for _ in pairs(items) do totalItems += 1 end
-        kvIndex = 1
-    end
-    if isTable then
-        for k, v in pairs(items) do
-            local itemKV = {k, v}
-            local item = GetItemByName(source, itemKV[kvIndex])
-            if item and ((amount and item.amount >= amount) or (not amount and not isArray and item.amount >= v) or (not amount and isArray)) then
-                count += 1
-            end
-        end
-        if count == totalItems then
-            retval = true
-        end
-    else -- Single item as string
-        local item = GetItemByName(source, items)
-        if item and not amount or (item and amount and item.amount >= amount) then
-            retval = true
-        end
-    end
-    cb(retval)
-end)
-]]--
-
 --#endregion Callbacks
 
 --#region Commands

--- a/server/main.lua
+++ b/server/main.lua
@@ -2065,6 +2065,7 @@ QBCore.Functions.CreateCallback('inventory:server:GetCurrentDrops', function(_, 
 	cb(Drops)
 end)
 
+--[[
 QBCore.Functions.CreateCallback('QBCore:HasItem', function(source, cb, items, amount)
 	print("^3QBCore:HasItem is deprecated, please use QBCore.Functions.HasItem, it can be used on both server- and client-side and uses the same arguments.^0")
     local retval = false
@@ -2099,6 +2100,7 @@ QBCore.Functions.CreateCallback('QBCore:HasItem', function(source, cb, items, am
     end
     cb(retval)
 end)
+]]--
 
 --#endregion Callbacks
 


### PR DESCRIPTION
## Description

Deprecate HasItem callback since it's not used anymore in any QB script.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
