### PR TITLE
Fix for Fire extinguisher spawning with 0 Ammo

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -570,7 +570,7 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
         local ammo = tonumber(weaponData.info.ammo) or 0
 
-        if weaponName == "weapon_petrolcan" then
+        if weaponName == "weapon_petrolcan" or weaponName == "weapon_fireextinguisher" then
             ammo = 4000
         end
 


### PR DESCRIPTION
## Description

This PR fixes where fire extinguisher spawns with 0 ammo which makes it useless . This PR fixes issue https://github.com/qbcore-framework/qb-smallresources/issues/285 and #130 .

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
