### PR TITLE
Fix weapon Attachment Issue

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -13,6 +13,7 @@ local CurrentGlovebox = nil
 local CurrentStash = nil
 local isCrafting = false
 local isHotbar = false
+local WeaponAttachments = WeaponAttachments
 
 --#endregion Variables
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -13,7 +13,6 @@ local CurrentGlovebox = nil
 local CurrentStash = nil
 local isCrafting = false
 local isHotbar = false
-local WeaponAttachments = WeaponAttachments
 
 --#endregion Variables
 
@@ -121,8 +120,8 @@ local function FormatWeaponAttachments(itemdata)
     itemdata.name = itemdata.name:upper()
     if itemdata.info.attachments ~= nil and next(itemdata.info.attachments) ~= nil then
         for _, v in pairs(itemdata.info.attachments) do
-            if WeaponAttachments[itemdata.name] ~= nil then
-                for key, value in pairs(WeaponAttachments[itemdata.name]) do
+            if exports['qb-weapons']:getConfigWeaponAttachments(itemdata.name) then
+                for key, value in pairs(exports['qb-weapons']:getConfigWeaponAttachments(itemdata.name)) do
                     if value.component == v.component then
                         local item = value.item
                         attachments[#attachments+1] = {
@@ -823,13 +822,13 @@ end)
 RegisterNUICallback('RemoveAttachment', function(data, cb)
     local ped = PlayerPedId()
     local WeaponData = QBCore.Shared.Items[data.WeaponData.name]
-    local Attachment = WeaponAttachments[WeaponData.name:upper()][data.AttachmentData.attachment]
+    local Attachment = exports['qb-weapons']:getConfigWeaponAttachments(WeaponData.name:upper())[data.AttachmentData.attachment]
     QBCore.Functions.TriggerCallback('weapons:server:RemoveAttachment', function(NewAttachments)
         if NewAttachments ~= false then
             local Attachies = {}
             RemoveWeaponComponentFromPed(ped, joaat(data.WeaponData.name), joaat(Attachment.component))
             for _, v in pairs(NewAttachments) do
-                for _, pew in pairs(WeaponAttachments[WeaponData.name:upper()]) do
+                for _, pew in pairs(exports['qb-weapons']:getConfigWeaponAttachments(WeaponData.name:upper())) do
                     if v.component == pew.component then
                         local item = pew.item
                         Attachies[#Attachies+1] = {

--- a/client/main.lua
+++ b/client/main.lua
@@ -13,7 +13,6 @@ local CurrentGlovebox = nil
 local CurrentStash = nil
 local isCrafting = false
 local isHotbar = false
-local WeaponAttachments = {}
 
 --#endregion Variables
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -9,7 +9,6 @@ shared_scripts {
     'locales/en.lua',
     'locales/*.lua',
     'config.lua',
-    '@qb-weapons/config.lua'
 }
 
 server_scripts {
@@ -32,5 +31,7 @@ files {
     'html/attachment_images/*.png',
     'html/*.ttf'
 }
+
+dependecy 'qb-weapons'
 
 lua54 'yes'


### PR DESCRIPTION
Fixed issue: #345 , #304, #299 

It was making variable WeaponAttachments empty in client.lua whereas we are importing it from qb-weapon config.lua