### PR TITLE
fix(app): Prevent unique items dropping into void

### DIFF
--- a/html/js/app.js
+++ b/html/js/app.js
@@ -1572,7 +1572,9 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
                 })
             );
         } else {
-            if (fromData.amount == $toAmount) {
+            if (fromData.amount == $toAmount &&
+                (toData == undefined || toData == null)
+            ) {
                 if (
                     toData != undefined &&
                     toData.combinable != null &&


### PR DESCRIPTION
## Description
Dropping a unique item onto a unique item in the first 5 slots would result in the item being transferred successfully to the same destination slot as it came from. i.e. if a unique item from slot 3 in player inventory was dropped onto a unique item in slot 1 (occupied slot) in secondary inventory, it would transfer to slot 3 of the secondary inventory (somewhat incorrectly - it should fail). However, if slot 3 was also occupied, then the item would end up into a void and disappear. A good demonstration can be seen here: https://github.com/qbcore-framework/qb-inventory/issues/308#issuecomment-1305512700

This PR resolves this issue, by adding a check to ensure the slot being dragged to is empty before transferring the item. If the slot is not empty, the transfer will not occur preventing the issue.

Fixes #308.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
