### PR TITLE
Show amount in ItemBox with received/removed and required items.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -420,7 +420,8 @@ RegisterNetEvent('inventory:client:requiredItems', function(items, bool)
     local itemTable = {}
     if bool then
         for k in pairs(items) do
-	    if items[k].amount ~= nil then amount = "x " .. items[k].amount else amount = "" end
+	    amount = ""
+	    if items[k].amount ~= nil then amount = "x " .. items[k].amount end
             itemTable[#itemTable+1] = {
                 item = items[k].name,
                 label = QBCore.Shared.Items[items[k].name]["label"],

--- a/client/main.lua
+++ b/client/main.lua
@@ -425,7 +425,7 @@ RegisterNetEvent('inventory:client:requiredItems', function(items, bool)
                 item = items[k].name,
                 label = QBCore.Shared.Items[items[k].name]["label"],
                 image = items[k].image,
-		amount = amount,
+		itemAmount = amount,
             }
         end
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -406,11 +406,13 @@ RegisterNetEvent('inventory:client:CheckOpenState', function(type, id, label)
     end
 end)
 
-RegisterNetEvent('inventory:client:ItemBox', function(itemData, type)
+RegisterNetEvent('inventory:client:ItemBox', function(itemData, type, amount)
+    if amount ~= nil then amount = "x " .. amount else amount = "" end
     SendNUIMessage({
         action = "itemBox",
         item = itemData,
-        type = type
+        type = type,
+	itemAmount = amount,
     })
 end)
 
@@ -418,10 +420,12 @@ RegisterNetEvent('inventory:client:requiredItems', function(items, bool)
     local itemTable = {}
     if bool then
         for k in pairs(items) do
+	    if items[k].amount ~= nil then amount = "x " .. items[k].amount else amount = "" end
             itemTable[#itemTable+1] = {
                 item = items[k].name,
                 label = QBCore.Shared.Items[items[k].name]["label"],
                 image = items[k].image,
+		amount = amount,
             }
         end
     end

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -2848,7 +2848,7 @@ var requiredItemOpen = false;
                         '<div class="requiredItem-box"><div id="requiredItem-action">Required</div><div id="requiredItem-label"><p>' +
                         item.label +
 			' ' +
-                        item.amount +
+                        item.itemAmount +
                         '</p></div><div id="requiredItem-image"><div class="item-slot-img"><img src="images/' +
                         item.image +
                         '" alt="' +

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -2819,6 +2819,8 @@ var requiredItemOpen = false;
             type +
             '</p></div><div id="itembox-label"><p>' +
             data.item.label +
+	    ' ' +
+            data.itemAmount +
             '</p></div><div class="item-slot-img"><img src="images/' +
             data.item.image +
             '" alt="' +
@@ -2845,6 +2847,8 @@ var requiredItemOpen = false;
                     var element =
                         '<div class="requiredItem-box"><div id="requiredItem-action">Required</div><div id="requiredItem-label"><p>' +
                         item.label +
+			' ' +
+                        item.amount +
                         '</p></div><div id="requiredItem-image"><div class="item-slot-img"><img src="images/' +
                         item.image +
                         '" alt="' +


### PR DESCRIPTION
## Description

Allows users to also pass an item amount when using the ItemBox to show received/removed and required items.

e.g. 
`TriggerEvent('inventory:client:ItemBox', QBCore.Shared.Items["glass"], "remove", 400)`

![preview](https://i.imgur.com/0ii8bap.png)

If no amount is defined then it will just use item name like previous to not create any issues with previous uses.

![preview](https://i.imgur.com/ckcakVr.png)

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
