### PR TITLE
Added condition in hotbar usage

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -787,7 +787,7 @@ RegisterKeyMapping('hotbar', Lang:t("inf_mapping.tog_slots"), 'keyboard', 'z')
 
 for i = 1, 6 do
     RegisterCommand('slot' .. i,function()
-        if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
+        if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() and not LocalPlayer.state.inv_busy then
             if i == 6 then
                 i = Config.MaxInventorySlots
             end


### PR DESCRIPTION
## Description

Added a condition which checks if the inventory is busy while using the hotbar items. So, if the inventory is busy then player will also not be able to use the items in hotbar. It fixes a lot of duping glitches.

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
