### PR TITLE
fix(client): Prevent inventory opening if NUI is already focused

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -659,6 +659,7 @@ RegisterCommand('closeinv', function()
 end, false)
 
 RegisterCommand('inventory', function()
+    if IsNuiFocused() then return end
     if not isCrafting and not inInventory then
         if not PlayerData.metadata["isdead"] and not PlayerData.metadata["inlaststand"] and not PlayerData.metadata["ishandcuffed"] and not IsPauseMenuActive() then
             local ped = PlayerPedId()


### PR DESCRIPTION
## Description
This PR prevents the inventory opening if another resource already has NUI focus. This was occurring if a user used `/tx` to open the tx admin, which uses TAB to cycle through the menu.

This issue was raised by Tabarra#1234 in Discord.
Ref: https://discord.com/channels/831626422232678481/1045830587694469241

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
