### PR TITLE
[SECURITY] Fix huge security flaw

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -2000,13 +2000,6 @@ RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, to
 	end
 end)
 
-RegisterNetEvent('qb-inventory:server:SaveStashItems', function(stashId, items)
-    MySQL.insert('INSERT INTO stashitems (stash, items) VALUES (:stash, :items) ON DUPLICATE KEY UPDATE items = :items', {
-        ['stash'] = stashId,
-        ['items'] = json.encode(items)
-    })
-end)
-
 RegisterServerEvent("inventory:server:GiveItem", function(target, name, amount, slot)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
## Description
This PR removes the event called `qb-inventory:server:SaveStashItems`. Which is used to update the items of **any** stash that exists in QBCore.
There is also no base qb-core script that even uses this event, making it useless to still have this.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
