### PR TITLE
[ENHANCEMENT] Better config for importing

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,4 @@
-Config = {}
+Config = Config or {}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 


### PR DESCRIPTION
## Description
Some scripts might want to import the config of qb-inventory to be able to read the max weight or such.
Which is currently quite annoying to do since the config of qb-inventory would overwrite the `Config` value.
With this change you can import qb-inventory´s config via `@qb-inventory/config.lua` without it overwriting the `Config` value for the local resource.

## Checklist
- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
