### PR TITLE
Dupe items trunk fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1105,3 +1105,7 @@ CreateThread(function()
 end)
 
 --#endregion Threads
+
+RegisterNUICallback('UpdateTrunkData', function()
+    TriggerServerEvent("inventory:server:SaveInventory", "trunk", CurrentVehicle)
+end)

--- a/html/js/app.js
+++ b/html/js/app.js
@@ -2152,6 +2152,9 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
                 InventoryError($fromInv, $fromSlot);
             }
         }
+        if ($fromInv.attr("data-inventory").search("trunk-") !== -1) {
+            $.post("https://qb-inventory/UpdateTrunkData", JSON.stringify({}))
+        }
     } else {
     }
     handleDragDrop();


### PR DESCRIPTION
Dupe items trunk fix

Fix trunk dupe items glitch. Save trunk data every time you remove an item from there.

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
