### PR TITLE
fix: trunk items for policejob

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Inventory'
-version '1.2.3'
+version '1.2.4'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',
@@ -15,6 +15,7 @@ server_scripts {
     '@oxmysql/lib/MySQL.lua',
     'server/main.lua'
 }
+
 client_script 'client/main.lua'
 
 ui_page {

--- a/server/main.lua
+++ b/server/main.lua
@@ -1339,15 +1339,19 @@ AddEventHandler('onResourceStart', function(resourceName)
 		end)
 	end
 end)
+
 RegisterNetEvent('QBCore:Server:UpdateObject', function()
     if source ~= '' then return end -- Safety check if the event was not called from the server.
     QBCore = exports['qb-core']:GetCoreObject()
 end)
+
 function addTrunkItems(plate, items)
 	Trunks[plate] = {}
 	Trunks[plate].items = items
 end
-exports('addTrunkItems',addTrunkItems)
+
+exports('addTrunkItems', addTrunkItems)
+
 function addGloveboxItems(plate, items)
 	Gloveboxes[plate] = {}
 	Gloveboxes[plate].items = items
@@ -2261,11 +2265,13 @@ RegisterNetEvent('inventory:server:snowball', function(action)
 		RemoveItem(source, "weapon_snowball")
 	end
 end)
-RegisterNetEvent('inventory:server:addTrunkItems', function()
-	print('inventory:server:addTrunkItems has been deprecated please use exports[\'qb-inventory\']:addTrunkItems(plate, items)')
+
+RegisterNetEvent('inventory:server:addTrunkItems', function(plate, items)
+	addTrunkItems(plate, items)
 end)
-RegisterNetEvent('inventory:server:addGloveboxItems', function()
-	print('inventory:server:addGloveboxItems has been deprecated please use exports[\'qb-inventory\']:addGloveboxItems(plate, items)')
+
+RegisterNetEvent('inventory:server:addGloveboxItems', function(plate, items)
+	addGloveboxItems(plate, items)
 end)
 --#endregion Events
 


### PR DESCRIPTION
## Description

At the moment with the latest qb-inventory & qb-policejob install, the trunk items are not added to PD vehicles trunks, this was due to [this](https://github.com/qbcore-framework/qb-inventory/commit/7561d634936b2ffa893fcfa5dcab9b417a5367c9) pull request, this is due to the exports being server sided and being called from a client side script, I have made it so the exported function is still called in Net event, so it can still be used from client side and fixed PD vehicles trunks not having any items added.

This fixes issue [#445](https://github.com/qbcore-framework/qb-policejob/issues/445) for qb-policejob

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
