### PR TITLE
Fix for inventory NUI being stuck on screen

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Inventory'
-version '1.2.2'
+version '1.2.3'
 
 shared_scripts {
     '@qb-core/shared/locale.lua',

--- a/server/main.lua
+++ b/server/main.lua
@@ -1634,6 +1634,7 @@ RegisterNetEvent('inventory:server:OpenInventory', function(name, id, other)
 			end
 		end
 		TriggerClientEvent("qb-inventory:client:closeinv", id)
+		Wait(0)
 		TriggerClientEvent("inventory:client:OpenInventory", src, {}, Player.PlayerData.items, secondInv)
 	else
 		TriggerClientEvent("inventory:client:OpenInventory", src, {}, Player.PlayerData.items)


### PR DESCRIPTION
## Description

At the moment if you try to access the police evidence stash, your cursor will not appear and you will be stuck in the inventory NUI, thanks to Man1C putting a simple frame wait after where the inventory is force closed then reopened fixes this issue this fixes [this](https://github.com/qbcore-framework/qb-policejob/issues/446) issue

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
