### PR TITLE
Update mysql statements

### DIFF
--- a/qb-inventory.sql
+++ b/qb-inventory.sql
@@ -1,50 +1,50 @@
 CREATE TABLE IF NOT EXISTS `gloveboxitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `plate` varchar(255) DEFAULT NULL,
-  `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`plate`),
-  KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+  `items` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `plate` (`plate`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `stashitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `stash` varchar(255) DEFAULT NULL,
-  `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`stash`),
-  KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+  `items` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `stash` (`stash`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `trunkitems` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `plate` varchar(255) DEFAULT NULL,
-  `items` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
-  PRIMARY KEY (`plate`),
-  KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;
+  `items` json DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `plate` (`plate`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `player_vehicles` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `id` int NOT NULL AUTO_INCREMENT,
   `license` varchar(50) DEFAULT NULL,
   `citizenid` varchar(50) DEFAULT NULL,
   `vehicle` varchar(50) DEFAULT NULL,
   `hash` varchar(50) DEFAULT NULL,
-  `mods` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL,
+  `mods` json DEFAULT NULL,
   `plate` varchar(50) NOT NULL,
   `fakeplate` varchar(50) DEFAULT NULL,
   `garage` varchar(50) DEFAULT NULL,
-  `fuel` int(11) DEFAULT 100,
+  `fuel` int DEFAULT 100,
   `engine` float DEFAULT 1000,
   `body` float DEFAULT 1000,
-  `state` int(11) DEFAULT 1,
-  `depotprice` int(11) NOT NULL DEFAULT 0,
-  `drivingdistance` int(50) DEFAULT NULL,
+  `state` int DEFAULT 1,
+  `depotprice` int NOT NULL DEFAULT 0,
+  `drivingdistance` int DEFAULT NULL,
   `status` text DEFAULT NULL,
-  `balance` int(11) NOT NULL DEFAULT 0,
-  `paymentamount` int(11) NOT NULL DEFAULT 0,
-  `paymentsleft` int(11) NOT NULL DEFAULT 0,
-  `financetime` int(11) NOT NULL DEFAULT 0,
+  `balance` int NOT NULL DEFAULT 0,
+  `paymentamount` int NOT NULL DEFAULT 0,
+  `paymentsleft` int NOT NULL DEFAULT 0,
+  `financetime` int NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `plate` (`plate`),
   KEY `citizenid` (`citizenid`),
   KEY `license` (`license`)
-) ENGINE=InnoDB AUTO_INCREMENT=1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
If you use a MySQL server, you can use the "json" instead of "longtext". If you still use MariaDB, the "json" will be translated back to "longtext". So this only has an impact on the aesthetics. In the newest MySQL version, integer must not contain length anymore. Also, the "Primary Key" should always have an integer as value, which is why all keys are placed on the id, and e.g. "plate" is treated as a normal key.

At last I set the charset to UTF8MB4.

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
Some changes of it will handle the removal of depracted values for the next mysql version.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
