### PR TITLE
added support of required distance for planes & helicopters

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -685,7 +685,14 @@ RegisterCommand('inventory', function()
                     if (IsBackEngine(GetEntityModel(vehicle))) then
                         trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y), 0.0)
                     end
-                    if #(pos - trunkpos) < 1.5 and not IsPedInAnyVehicle(ped) then
+						
+		local dist = 1.5
+                    if GetVehicleClass(vehicle) == 15 or GetVehicleClass(vehicle) == 16 then
+                        trunkpos = GetOffsetFromEntityInWorldCoords(vehicle, 0.0, (dimensionMax.y), 0.0) 
+                        dist = 4.5 
+                    end				
+						
+                    if #(pos - trunkpos) < dist and not IsPedInAnyVehicle(ped) then
                         if GetVehicleDoorLockStatus(vehicle) < 2 then
                             CurrentVehicle = QBCore.Functions.GetPlate(vehicle)
                             curVeh = vehicle


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
This code sets all planes and helicopters to rear engine and adjusts the required distance. Without this change, it is difficult to find a good position to open the trunk of planes & helicopters.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
