### PR TITLE
Fixed Inventory bug | Use slot1-2-3-4-5

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -797,6 +797,7 @@ for i = 1, 6 do
                 i = Config.MaxInventorySlots
             end
             TriggerServerEvent("inventory:server:UseItemSlot", i)
+	    closeInventory()
         end
     end, false)
     RegisterKeyMapping('slot' .. i, Lang:t("inf_mapping.use_item") .. i, 'keyboard', i)


### PR DESCRIPTION
Here We Fixed the Inventory Bug Where When We Use slot1 will inventory is open item used without closing inventory? So simply you need to open inventory and use slot1-2-3-4-5 any slot in F8 and once progress bar start drop that item to change the slot from inventoy here we just fixed it

## Checklist
Personally verified it on localhost & On Going Server
