### PR TITLE
Get Max Weight and Slots

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -3,7 +3,9 @@ Config = {}
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
 Config.MaxInventoryWeight = 120000 -- Max weight a player can carry (default 120kg, written in grams)
+exports("GetMaxWeight", function() return Config.MaxInventoryWeight end)
 Config.MaxInventorySlots = 41 -- Max inventory slots for a player
+exports("GetMaxSlots", function() return Config.MaxInventorySlots end)
 
 Config.KeyBinds = {
     Inventory = 'TAB',


### PR DESCRIPTION
This is a request to get some way to get max slots and weight so other scripts can adapt ex some reason a script needs to know thats the 6 slot? or to check if the player actualy can hold something before preforming a action?!

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
