### PR TITLE
Move trunk size to config

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -13,68 +13,6 @@ local CurrentGlovebox = nil
 local CurrentStash = nil
 local isCrafting = false
 local isHotbar = false
-local trunkSize = {
-    [0] = {
-        maxweight = 38000,
-        slots = 30
-    },
-    [1] = {
-        maxweight = 50000,
-        slots = 40
-    },
-    [2] = {
-        maxweight = 75000,
-        slots = 50
-    },
-    [3] = {
-        maxweight = 42000,
-        slots = 35
-    },
-    [4] = {
-        maxweight = 38000,
-        slots = 30
-    },
-    [5] = {
-        maxweight = 30000,
-        slots = 25
-    },
-    [6] = {
-        maxweight = 30000,
-        slots = 25
-    },
-    [7] = {
-        maxweight = 30000,
-        slots = 25
-    },
-    [8] = {
-        maxweight = 15000,
-        slots = 15
-    },
-    [9] = { -- default weight if no class is set
-        maxweight = 60000,
-        slots = 35
-    },
-    [12] = {
-        maxweight = 120000,
-        slots = 25
-    },
-    [13] = {
-        maxweight = 0,
-        slots = 0
-    },
-    [14] = {
-        maxweight = 120000,
-        slots = 50
-    },
-    [15] = {
-        maxweight = 120000,
-        slots = 50
-    },
-    [16] = {
-        maxweight = 120000,
-        slots = 50
-    }
-}
 
 --#endregion Variables
 
@@ -229,10 +167,9 @@ local function CloseTrunk()
         SetVehicleDoorShut(vehicle, 5, false)
     end
 end
-
 ---Checks weight and size of the vehicle trunk
 local function GetTrunkSize(vehicleClass)
-    if not trunkSize[vehicleClass] then vehicleClass = 9 end
+    local trunkSize = Config.TrunkSpace[vehicleClass] or Config.TrunkSpace["default"]
     return trunkSize[vehicleClass].maxweight, trunkSize[vehicleClass].slots
 end
 exports("GetTrunkSize", GetTrunkSize)
@@ -773,11 +710,17 @@ RegisterCommand('inventory', function()
 
             if CurrentVehicle then -- Trunk
                 local vehicleClass = GetVehicleClass(curVeh)
-                local maxweight, slots = GetTrunkSize(vehicleClass)
+                local trunkConfig = Config.TrunkSpace[vehicleClass] or Config.TrunkSpace["default"]
+                if not trunkConfig then return print("Cannot get the vehicle trunk config") end
+                local slots = trunkConfig.slots
+                local maxweight = trunkConfig.maxWeight
+                if not slots or not maxweight then return print("Cannot get the vehicle slots and maxweight") end
+
                 local other = {
                     maxweight = maxweight,
                     slots = slots,
                 }
+
                 TriggerServerEvent("inventory:server:OpenInventory", "trunk", CurrentVehicle, other)
                 OpenTrunk()
             elseif CurrentGlovebox then

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,4 @@
-Config = Config or {}
+Config = {}
 
 Config.UseTarget = GetConvar('UseTarget', 'false') == 'true' -- Use qb-target interactions (don't change this, go to your server.cfg and add `setr UseTarget true` to use this and just that from true to false or the other way around)
 
@@ -43,6 +43,76 @@ Config.VendingItem = {
         info = {},
         type = "item",
         slot = 2,
+    },
+}
+
+-- See the vehicle class here: https://docs.fivem.net/natives/?_0x29439776AAA00A62
+-- The template:
+-- [vehicleClass] = {slots = [number], maxWeight = [number]}
+Config.TrunkSpace = {
+    ["default"] = { -- All the vehicle class that not listed here will use this as default
+        slots = 35,
+        maxWeight = 60000
+    },
+    [0] = { -- Compacts
+        slots = 30,
+        maxWeight = 38000
+    },
+    [1] = { -- Sedans
+        slots = 40,
+        maxWeight = 50000
+    },
+    [2] = { -- SUVs
+        slots = 50,
+        maxWeight = 75000
+    },
+    [3] = { -- Coupes
+        slots = 35,
+        maxWeight = 42000
+    },
+    [4] = { -- Muscle
+        slots = 30,
+        maxWeight = 38000
+    },
+    [5] = { -- Sports Classics
+        slots = 25,
+        maxWeight = 30000
+    },
+    [6] = { -- Sports
+        slots = 25,
+        maxWeight = 30000
+    },
+    [7] = { -- Super
+        slots = 25,
+        maxWeight = 30000
+    },
+    [8] = { -- Motorcycles
+        slots = 15,
+        maxWeight = 15000
+    },
+    [9] = { -- Off-road
+        slots = 35,
+        maxWeight = 60000
+    },
+    [12] = { -- Vans
+        slots = 35,
+        maxWeight = 120000
+    },
+    [13] = { -- Cycles
+        slots = 0,
+        maxWeight = 0
+    },
+    [14] = { -- Boats
+        slots = 50,
+        maxWeight = 120000
+    },
+    [15] = { -- Helicopters
+        slots = 50,
+        maxWeight = 120000
+    },
+    [16] = { -- Planes
+        slots = 50,
+        maxWeight = 120000
     },
 }
 


### PR DESCRIPTION
## Description
Move the trunk weight and slots to config for easier editing. Also make the changes in the trunk size exports to compatible with the new config.

## Checklist
- [Checked] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [Checked] My code fits the style guidelines.
- [Checked] My PR fits the contribution guidelines.
