### PR TITLE
Added config for throwable items

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -622,13 +622,6 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         RemoveAllPedWeapons(ped, true)
         TriggerEvent('weapons:client:SetCurrentWeapon', nil, shootbool)
         currentWeapon = nil
-    elseif weaponName == "weapon_stickybomb" or weaponName == "weapon_pipebomb" or weaponName == "weapon_smokegrenade" or weaponName == "weapon_flare" or weaponName == "weapon_proxmine" or weaponName == "weapon_ball"  or weaponName == "weapon_molotov" or weaponName == "weapon_grenade" or weaponName == "weapon_bzgas" then
-        TriggerEvent('weapons:client:DrawWeapon', weaponName)
-        GiveWeaponToPed(ped, weaponHash, 1, false, false)
-        SetPedAmmo(ped, weaponHash, 1)
-        SetCurrentPedWeapon(ped, weaponHash, true)
-        TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
-        currentWeapon = weaponName
     elseif weaponName == "weapon_snowball" then
         TriggerEvent('weapons:client:DrawWeapon', weaponName)
         GiveWeaponToPed(ped, weaponHash, 10, false, false)
@@ -638,6 +631,18 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
         currentWeapon = weaponName
     else
+        for _,v in pairs(Config.Throwables) do
+            print(weaponName, v)
+            if weaponName == v then
+                TriggerEvent('weapons:client:DrawWeapon', weaponName)
+                GiveWeaponToPed(ped, weaponHash, 1, false, false)
+                SetPedAmmo(ped, weaponHash, 1)
+                SetCurrentPedWeapon(ped, weaponHash, true)
+                TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
+                currentWeapon = weaponName
+                return
+            end
+        end
         TriggerEvent('weapons:client:DrawWeapon', weaponName)
         TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
         local ammo = tonumber(weaponData.info.ammo) or 0

--- a/config.lua
+++ b/config.lua
@@ -385,3 +385,17 @@ Config.MaximumAmmoValues = {
     ["shotgun"] = 200,
     ["rifle"] = 250,
 }
+
+Config.Throwables = {
+    "weapon_ball",
+    "weapon_bzgas",
+    "weapon_flare",
+    "weapon_grenade",
+    "weapon_molotov",
+    "weapon_pipebomb",
+    "weapon_proxmine",
+    "weapon_smokegrenade",
+    "weapon_snowball",
+    "weapon_stickybomb",
+    "weapon_flashbang",
+}


### PR DESCRIPTION
Added config for throwable items and giving ammo accordingly

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
The PR adds a table for throwable weapons in the config.lua and uses that list instead of hardchecking when equipping a weapon.

It should be merged, because it makes it clear for people which weapons are throwables and should receive 1 ammo. Usefull for when adding custom weapons

It kind of fixes an issue, because it makes the script more flexible for customisation & addon weapons instead of relying on hard typed if-statements
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
