### PR TITLE
Weapon Tint Fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -578,6 +578,7 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         TriggerEvent('weapons:client:DrawWeapon', weaponName)
         TriggerEvent('weapons:client:SetCurrentWeapon', weaponData, shootbool)
         local ammo = tonumber(weaponData.info.ammo) or 0
+        local tint = tonumber(weaponData.info.tint) or 0
 
         if weaponName == "weapon_petrolcan" or weaponName == "weapon_fireextinguisher" then
             ammo = 4000
@@ -586,6 +587,7 @@ RegisterNetEvent('inventory:client:UseWeapon', function(weaponData, shootbool)
         GiveWeaponToPed(ped, weaponHash, ammo, false, false)
         SetPedAmmo(ped, weaponHash, ammo)
         SetCurrentPedWeapon(ped, weaponHash, true)
+        SetPedWeaponTintIndex(ped, weaponHash, tint)
 
         if weaponData.info.attachments then
             for _, attachment in pairs(weaponData.info.attachments) do


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? --> Fixes weapon tint not saving while being applied. (Other changes in qb-weapons)

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
