### PR TITLE
[Prevention] Timeout-based Client>Server Validation for Inventory Updates

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -900,7 +900,7 @@ RegisterNUICallback("SetInventoryData", function(data, cb)
     local isTimeoutOccurred = false
     local currentRequestId = GetGameTimer()
     QBCore.Functions.TriggerCallback('inventory:requestserver', function(isConnected, requestId)
-        if requestId ~= currentRequestId or isTimeoutOccurred then 
+        if requestId ~= currentRequestId or isTimeoutOccurred then
             return
         end
         isResponseReceived = true

--- a/client/main.lua
+++ b/client/main.lua
@@ -899,24 +899,20 @@ RegisterNUICallback("SetInventoryData", function(data, cb)
     local isResponseReceived = false
     local isTimeoutOccurred = false
     local currentRequestId = GetGameTimer()
-
     QBCore.Functions.TriggerCallback('inventory:requestserver', function(isConnected, requestId)
         if requestId ~= currentRequestId or isTimeoutOccurred then 
             return
         end
-
         isResponseReceived = true
-
         if isConnected then
             TriggerServerEvent('inventory:server:SetInventoryData', data.fromInventory, data.toInventory, data.fromSlot, data.toSlot, data.fromAmount, data.toAmount)
             cb('ok')
         end
     end, currentRequestId)
-
     Citizen.SetTimeout(2000, function()
         if not isResponseReceived then
             isTimeoutOccurred = true
-            TriggerServerEvent("inventory:statusBreak", data.fromInventory, data.toInventory, data.fromSlot, data.toSlot, data.fromAmount, data.toAmount)
+            TriggerServerEvent("inventory:statusBreak", data)
         end
     end)
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1719,16 +1719,25 @@ QBCore.Functions.CreateCallback('inventory:requestserver', function(source, cb, 
 end)
 
 RegisterNetEvent('inventory:statusBreak', function(data)
-    local src = source
-    local Player = QBCore.Functions.GetPlayer(src)
-    if Player then
-        local CitizenID = Player.PlayerData.citizenid
-        local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
+	local src = source
+	local Player = QBCore.Functions.GetPlayer(src)
+	local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
         local discordMention = "<@" .. discordId .. ">"
-        --TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**")
-        DropPlayer(src, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
-    end
-end)
+	local content = {
+		{
+			["color"] = '2302179',
+			["title"] = "**Player Kicked**",
+			["description"] = "**"..discordMention .. " / "..GetPlayerName(src).."** was kicked for inventory action timeout. \n\n From: **" ..data.fromInventory.." \n **To:** "..data.toInventory.."**",			
+			["footer"] = {
+			["text"] = "Inventory",
+	            	},
+	        }
+	    }
+		PerformHttpRequest("YOUR_DISCORD_WEBHOOK_LINK", function(err, text, headers) end, 'POST', json.encode({username = "Inventory", embeds = content}), { ['Content-Type'] = 'application/json' })	
+		--TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**")
+		DropPlayer(source, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
+
+	end)
 
 RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
 	local src = source

--- a/server/main.lua
+++ b/server/main.lua
@@ -1719,25 +1719,23 @@ QBCore.Functions.CreateCallback('inventory:requestserver', function(source, cb, 
 end)
 
 RegisterNetEvent('inventory:statusBreak', function(data)
-	local src = source
-	local Player = QBCore.Functions.GetPlayer(src)
-	local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
-        local discordMention = "<@" .. discordId .. ">"
-	local content = {
-		{
-			["color"] = '2302179',
-			["title"] = "**Player Kicked**",
-			["description"] = "**"..discordMention .. " / "..GetPlayerName(src).."** was kicked for inventory action timeout. \n\n From: **" ..data.fromInventory.." \n **To:** "..data.toInventory.."**",			
-			["footer"] = {
-			["text"] = "Inventory",
-	            	},
-	        }
-	    }
-		PerformHttpRequest("YOUR_DISCORD_WEBHOOK_LINK", function(err, text, headers) end, 'POST', json.encode({username = "Inventory", embeds = content}), { ['Content-Type'] = 'application/json' })	
-		--TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**")
-		DropPlayer(source, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
-
-	end)
+    local src = source
+    local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
+    local discordMention = "<@" .. discordId .. ">"
+    local content = {
+        {
+            ["color"] = '2302179',
+            ["title"] = "**Player Kicked**",
+            ["description"] = "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory action timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**",
+            ["footer"] = {
+                ["text"] = "Inventory",
+            },
+        }
+    }
+    PerformHttpRequest("YOUR_DISCORD_WEBHOOK_LINK", function(_, _, _) end, 'POST', json.encode({username = "Inventory", embeds = content}), { ['Content-Type'] = 'application/json' })
+    --TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**")
+    DropPlayer(src, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
+end)
 
 RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
 	local src = source

--- a/server/main.lua
+++ b/server/main.lua
@@ -1718,14 +1718,14 @@ QBCore.Functions.CreateCallback('inventory:requestserver', function(source, cb, 
     end
 end)
 
-RegisterNetEvent('inventory:statusBreak', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
+RegisterNetEvent('inventory:statusBreak', function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if Player then
         local CitizenID = Player.PlayerData.citizenid
         local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
         local discordMention = "<@" .. discordId .. ">"
-        --TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. fromInventory .. " \n **To:** " .. toInventory .. "**")
+        --TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. data.fromInventory .. " \n **To:** " .. data.toInventory .. "**")
         DropPlayer(src, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
     end
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1709,6 +1709,27 @@ RegisterNetEvent('inventory:server:UseItem', function(inventory, item)
 	end
 end)
 
+QBCore.Functions.CreateCallback('inventory:requestserver', function(source, cb, requestId)
+    local Player = QBCore.Functions.GetPlayer(source)
+    if Player then
+        cb(true, requestId)
+    else
+        cb(false, requestId)
+    end
+end)
+
+RegisterNetEvent('inventory:statusBreak', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if Player then
+        local CitizenID = Player.PlayerData.citizenid
+        local discordId = QBCore.Functions.GetIdentifier(src, 'discord'):gsub("discord:", "")
+        local discordMention = "<@" .. discordId .. ">"
+        --TriggerEvent("qb-log:server:CreateLog", "inventory", "Player Kicked", "orange", "**" .. discordMention .. " / " .. GetPlayerName(src) .. "** was kicked for inventory timeout. \n\n From: **" .. fromInventory .. " \n **To:** " .. toInventory .. "**")
+        DropPlayer(src, "Something went wrong. \n\n If you or the server were experiencing network issues or timing out, simply relaunch your game and reconnect.")
+    end
+end)
+
 RegisterNetEvent('inventory:server:SetInventoryData', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
 	local src = source
 	local Player = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
## Description

Legitimate client inventory data updates will rely on a validation response from the server when attempted.

Players using internet disruption techniques to dupe items in your server will be kicked instead of data being updated and exploited once connections re-established. Additionally, if the action takes longer than 2 seconds to receive a server response for the transaction ID, player is kicked.

Two logging options can be found in the server event `'inventory:statusBreak'`


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
