### PR TITLE
Add Japanese Localization

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -88,7 +88,11 @@ end
 ---@param text string The text to display
 local function DrawText3Ds(x, y, z, text)
     SetTextScale(0.35, 0.35)
-    SetTextFont(4)
+    if GetConvar('qb_locale', 'en') == 'en' then
+        SetTextFont(4)
+    else
+        SetTextFont(1)
+    end
     SetTextProportional(1)
     SetTextColour(255, 255, 255, 215)
     SetTextEntry('STRING')

--- a/locales/ja.lua
+++ b/locales/ja.lua
@@ -1,0 +1,61 @@
+local Translations = {
+    progress = {
+        ["crafting"] = "クラフト中...",
+        ["snowballs"] = "雪玉集め中..",
+    },
+    notify = {
+        ["failed"] = "失敗しました",
+        ["canceled"] = "キャンセルしました",
+        ["vlocked"] = "乗り物をロックしました",
+        ["notowned"] = "この商品は所有していません!",
+        ["missitem"] = "このアイテムを持っていません!",
+        ["nonb"] = "近くに誰もいません!",
+        ["noaccess"] = "アクセスできません",
+        ["nosell"] = "このアイテムは売ることができません..",
+        ["itemexist"] = "アイテムがありません",
+        ["notencash"] = "現金が足りません..",
+        ["noitem"] = "正しいアイテムを持っていません..",
+        ["gsitem"] = "アイテムは自分へは渡せません",
+        ["tftgitem"] = "相手との距離が遠いためアイテムを渡せません!",
+        ["infound"] = "アイテムが見つかりません!",
+        ["iifound"] = "間違ったアイテムです!",
+        ["gitemrec"] = "アイテムを受け取りました: ",
+        ["gitemfrom"] = " 渡した人: ",
+        ["gitemyg"] = "アイテムを渡した: ",
+        ["gitinvfull"] = "相手のインベントリがいっぱいなので渡せません!",
+        ["giymif"] = "インベントリがいっぱいで受け取れません!",
+        ["gitydhei"] = "アイテムの数が足りません",
+        ["gitydhitt"] = "転送するアイテムが足りません",
+        ["navt"] = "有効な種類ではありません",
+        ["anfoc"] = "引数が正しく入力されていません..",
+        ["yhg"] = "アイテムを渡した: ",
+        ["cgitem"] = "アイテムを渡せませんでした!",
+        ["idne"] = "アイテムが見つかりません",
+        ["pdne"] = "プレイヤーはオフラインです",
+    },
+    inf_mapping = {
+        ["opn_inv"] = "インベントリを開く",
+        ["tog_slots"] = "キー割り当てスロットを切り替え",
+        ["use_item"] = "アイテムを使用: ",
+    },
+    menu = {
+        ["vending"] = "自動販売機",
+        ["craft"] = "クラフト",
+        ["o_bag"] = "バッグを開く",
+    },
+    interaction = {
+        ["craft"] = "~g~E~w~ - クラフト",
+    },
+    label = {
+        ["craft"] = "クラフト",
+        ["a_craft"] = "アタッチメントのクラフト",
+    },
+}
+
+if GetConvar('qb_locale', 'en') == 'ja' then
+    Lang = Locale:new({
+        phrases = Translations,
+        warnOnMissing = true,
+        fallbackLang = Lang,
+    })
+end


### PR DESCRIPTION
## Description
This is a PR to add Japanese to the localization.  
Since font 4 is only ASCII characters, the process has been changed so that non-English characters are set to font 1.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
