### PR TITLE
:bug: Fixes GetTrunkSize export

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -177,7 +177,7 @@ end
 ---Checks weight and size of the vehicle trunk
 local function GetTrunkSize(vehicleClass)
     local trunkSize = Config.TrunkSpace[vehicleClass] or Config.TrunkSpace['default']
-    return trunkSize[vehicleClass].maxweight, trunkSize[vehicleClass].slots
+    return trunkSize.maxWeight, trunkSize.slots
 end
 exports('GetTrunkSize', GetTrunkSize)
 


### PR DESCRIPTION
## Description

Fixes the GetTrunkSize export. Previously would try to gather a table from the trunk weight and slots, but that's not how it's configured in the config.
```
[0] = { -- Compacts
        slots = 30,
        maxWeight = 38000
    },
```

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
