### PR TITLE
fix(command): txAdmin default hotkey support

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -285,6 +285,7 @@ end)
 -- Commands
 
 RegisterCommand('openInv', function()
+    if IsNuiFocused() then return end
     ExecuteCommand('inventory')
 end, false)
 


### PR DESCRIPTION
## Description

fixes the default txAdmin tab when having its panel already open

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
