### PR TITLE
fix(command): big map point of interest conflict

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -285,7 +285,7 @@ end)
 -- Commands
 
 RegisterCommand('openInv', function()
-    if IsNuiFocused() then return end
+    if IsNuiFocused() or IsPauseMenuActive() then return end
     ExecuteCommand('inventory')
 end, false)
 


### PR DESCRIPTION
## Description

fixes conflict with point of interest in the big map having both the same default key (tab)

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X] My code fits the style guidelines.
- [X] My PR fits the contribution guidelines.
