### PR TITLE
fix: amount is nil in `GetTotalWeight` + misc lint issues

### DIFF
--- a/client/drops.lua
+++ b/client/drops.lua
@@ -1,4 +1,4 @@
-local holdingDrop = false
+HoldingDrop = false
 local bagObject = nil
 local heldDrop = nil
 CurrentDrop = nil
@@ -59,9 +59,9 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
                 label = 'Pick up bag',
                 action = function()
                     if IsPedArmed(PlayerPedId(), 4) then
-                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500) 
+                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500)
                     end
-                    if holdingDrop then
+                    if HoldingDrop then
                         return QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)
                     end
                     AttachEntityToEntity(
@@ -77,7 +77,7 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
                         true, true, false, true, 1, true
                     )
                     bagObject = bag
-                    holdingDrop = true
+                    HoldingDrop = true
                     heldDrop = newDropId
                     exports['qb-core']:DrawText('Press [G] to drop the bag')
                 end,
@@ -109,7 +109,7 @@ end)
 
 CreateThread(function()
     while true do
-        if holdingDrop then
+        if HoldingDrop then
             if IsControlJustPressed(0, 47) then
                 DetachEntity(bagObject, true, true)
                 local coords = GetEntityCoords(PlayerPedId())
@@ -119,7 +119,7 @@ CreateThread(function()
                 FreezeEntityPosition(bagObject, true)
                 exports['qb-core']:HideText()
                 TriggerServerEvent('qb-inventory:server:updateDrop', heldDrop, coords)
-                holdingDrop = false
+                HoldingDrop = false
                 bagObject = nil
                 heldDrop = nil
             end

--- a/client/drops.lua
+++ b/client/drops.lua
@@ -18,7 +18,7 @@ function GetDrops()
                                 label = Lang:t('menu.o_bag'),
                                 action = function()
                                     TriggerServerEvent('qb-inventory:server:openDrop', k)
-                                    CurrentDrop = dropId
+                                    CurrentDrop = k
                                 end,
                             },
                         },

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,7 +1,6 @@
 QBCore = exports['qb-core']:GetCoreObject()
 PlayerData = nil
 local hotbarShown = false
-local PlayerData = nil
 
 -- Handlers
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,6 @@
 QBCore = exports['qb-core']:GetCoreObject()
 local hotbarShown = false
+local PlayerData = nil
 
 -- Handlers
 
@@ -11,7 +12,7 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     LocalPlayer.state:set('inv_busy', true, true)
-    PlayerData = {}
+    PlayerData = nil
 end)
 
 RegisterNetEvent('QBCore:Client:UpdateObject', function()
@@ -78,19 +79,21 @@ function HasItem(items, amount)
         for _ in pairs(items) do totalItems = totalItems + 1 end
     end
 
-    for _, itemData in pairs(PlayerData.items) do
-        if isTable then
-            for k, v in pairs(items) do
-                if itemData and itemData.name == (isArray and v or k) and ((amount and itemData.amount >= amount) or (not isArray and itemData.amount >= v) or (not amount and isArray)) then
-                    count = count + 1
-                    if count == totalItems then
-                        return true
+    if PlayerData and type(PlayerData.items) == "table" then
+        for _, itemData in pairs(PlayerData.items) do
+            if isTable then
+                for k, v in pairs(items) do
+                    if itemData and itemData.name == (isArray and v or k) and ((amount and itemData.amount >= amount) or (not isArray and itemData.amount >= v) or (not amount and isArray)) then
+                        count = count + 1
+                        if count == totalItems then
+                            return true
+                        end
                     end
                 end
-            end
-        else -- Single item as string
-            if itemData and itemData.name == items and (not amount or (itemData and amount and itemData.amount >= amount)) then
-                return true
+            else -- Single item as string
+                if itemData and itemData.name == items and (not amount or (itemData and amount and itemData.amount >= amount)) then
+                    return true
+                end
             end
         end
     end
@@ -137,9 +140,14 @@ RegisterNetEvent('qb-inventory:client:closeInv', function()
 end)
 
 RegisterNetEvent('qb-inventory:client:updateInventory', function()
+    local items = {}
+    if PlayerData and type(PlayerData.items) == "table" then
+        items = PlayerData.items
+    end
+
     SendNUIMessage({
         action = 'update',
-        inventory = PlayerData.items
+        inventory = items
     })
 end)
 
@@ -298,9 +306,11 @@ end, false)
 
 for i = 1, 5 do
     RegisterCommand('slot_' .. i, function()
-        local itemData = PlayerData.items[i]
-        if not itemData then return end
-        TriggerServerEvent('qb-inventory:server:useItem', itemData)
+        if PlayerData and type(PlayerData.items) == "table" then
+            local itemData = PlayerData.items[i]
+            if not itemData then return end
+            TriggerServerEvent('qb-inventory:server:useItem', itemData)
+        end
     end, false)
     RegisterKeyMapping('slot_' .. i, Lang:t('inf_mapping.use_item') .. i, 'keyboard', i)
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -309,7 +309,7 @@ for i = 1, 5 do
         local itemData = PlayerData.items[i]
         if not itemData then return end
         if itemData.type == "weapon" then
-            if holdingDrop then
+            if HoldingDrop then
                 return QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)
             end
         end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -219,7 +219,12 @@ function GetTotalWeight(items)
     if not items then return 0 end
     local weight = 0
     for _, item in pairs(items) do
-        weight = weight + (item.weight * item.amount)
+        local amount = item.amount
+        if type(amount) ~= "number" then
+            amount = 1
+        end
+
+        weight = weight + (item.weight * amount)
     end
     return tonumber(weight)
 end


### PR DESCRIPTION
## Description
Upon running `/giveitem 1 radio 1`, you'll run into the following error.
![image](https://github.com/qbcore-framework/qb-inventory/assets/54480523/4d0e78ef-d4cf-4bcf-a6c1-63fb7a2871a7)
(First print is raw item json, second print is weight & amount)

Perhaps this should be looked into more deeply, as the amount value should be defined here.
Aswell as the fact that this error might be happening at other places

Perhaps, this is caused by the radio being a unique item?

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.