### PR TITLE
fix: `vendingMachineCoords` is undefined

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -132,14 +132,14 @@ end
 
 -- Events
 
-RegisterNetEvent('qb-inventory:server:openVending', function()
+RegisterNetEvent('qb-inventory:server:openVending', function(data)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
     CreateShop({
         name = 'vending',
         label = 'Vending Machine',
-        coords = vendingMachineCoords,
+        coords = data.coords,
         slots = #Config.VendingItems,
         items = Config.VendingItems
     })


### PR DESCRIPTION
## Description

This fixes an issue with the coordinates upon opening a vending machine being defined.

This needs to be merged along side this PR:
https://github.com/qbcore-framework/qb-target/pull/203

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
