### PR TITLE
Mechomancer patch 1

### DIFF
--- a/server/commands.lua
+++ b/server/commands.lua
@@ -29,8 +29,6 @@ QBCore.Commands.Add('giveitem', 'Give An Item (Admin Only)', { { name = 'id', he
                 info.uses = 20
             elseif itemData['name'] == 'markedbills' then
                 info.worth = math.random(5000, 10000)
-            elseif itemData['name'] == 'labkey' then
-                info.lab = exports['qb-methlab']:GenerateRandomLab()
             elseif itemData['name'] == 'printerdocument' then
                 info.url = 'https://cdn.discordapp.com/attachments/870094209783308299/870104331142189126/Logo_-_Display_Picture_-_Stylized_-_Red.png'
             end

--- a/server/main.lua
+++ b/server/main.lua
@@ -160,7 +160,7 @@ RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
     if Drops[inventory] then
         Drops[inventory].isOpen = false
         if #Drops[inventory].items == 0 and not Drops[inventory].isOpen then -- if no listeed items in the drop on close
-            TriggerClientEvent('qb-inventory:client:removeDropTarget', Drops[inventory].entityId)
+            TriggerClientEvent('qb-inventory:client:removeDropTarget', -1, Drops[inventory].entityId)
             Wait(500)
             local entity = NetworkGetEntityFromNetworkId(Drops[inventory].entityId)
             if DoesEntityExist(entity) then DeleteEntity(entity) end

--- a/server/main.lua
+++ b/server/main.lua
@@ -159,6 +159,13 @@ RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
     end
     if Drops[inventory] then
         Drops[inventory].isOpen = false
+        if #Drops[inventory].items == 0 and not Drops[inventory].isOpen then -- if no listeed items in the drop on close
+            TriggerClientEvent('qb-inventory:client:removeDropTarget', Drops[inventory].entityId)
+            Wait(500)
+            local entity = NetworkGetEntityFromNetworkId(Drops[inventory].entityId)
+            if DoesEntityExist(entity) then DeleteEntity(entity) end
+            Drops[inventory] = nil
+        end
         return
     end
     if not Inventories[inventory] then return end

--- a/server/main.lua
+++ b/server/main.lua
@@ -274,7 +274,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
 
     if Player.PlayerData.money.cash >= price then
         Player.Functions.RemoveMoney('cash', price, 'shop-purchase')
-        AddItem(source, itemInfo.name, amount, nil, itemInfo.info)
+        AddItem(source, itemInfo.name, amount, nil, itemInfo.info, 'shop-purchase')
         TriggerEvent('qb-shops:server:UpdateShopItems', shop, itemInfo, amount)
         cb(true)
     else


### PR DESCRIPTION
## Description
This fixes a multiple drops issue i discovered as it never deletes the drop when empty. this allows you to also pick up an empty drop and then another leaving the first one stuck to the player. So now it also catches if your already carrying a bag you can not pick up another one till you drop the current one.

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
