### PR TITLE
Use on context menu shows up only on useable items

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -191,7 +191,7 @@
                 </div>
             </div>
             <ul v-if="showContextMenu" class="context-menu" :style="{ top: contextMenuPosition.top, left: contextMenuPosition.left }">
-                <li @click="useItem(contextMenuItem)">Use</li>
+                <li v-if="contextMenuItem.useable" @click="useItem(contextMenuItem)">Use</li>
                 <li @mouseover="showSubmenu = true" @mouseleave="showSubmenu = false">
                     Give
                     <ul v-if="showSubmenu" class="submenu">


### PR DESCRIPTION
Added a check to see if the item is useable.
if the item isnt useable theres no reason to show the "use" in the contextmenu

## Description
makes the Use option in the context menu when you right click an item only show if the item is useable.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X ] My code fits the style guidelines.
- [ X] My PR fits the contribution guidelines.
