### PR TITLE
(fix) Save `source` to local Var

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -174,15 +174,16 @@ RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
 end)
 
 RegisterNetEvent('qb-inventory:server:useItem', function(item)
-    local itemData = GetItemBySlot(source, item.slot)
+    local src = source
+    local itemData = GetItemBySlot(src, item.slot)
     if not itemData then return end
     local itemInfo = QBCore.Shared.Items[itemData.name]
     if itemData.type == 'weapon' then
-        TriggerClientEvent('qb-weapons:client:UseWeapon', source, itemData, itemData.info.quality and itemData.info.quality > 0)
-        TriggerClientEvent('qb-inventory:client:ItemBox', source, itemInfo, 'use')
+        TriggerClientEvent('qb-weapons:client:UseWeapon', src, itemData, itemData.info.quality and itemData.info.quality > 0)
+        TriggerClientEvent('qb-inventory:client:ItemBox', src, itemInfo, 'use')
     else
-        UseItem(itemData.name, source, itemData)
-        TriggerClientEvent('qb-inventory:client:ItemBox', source, itemInfo, 'use')
+        UseItem(itemData.name, src, itemData)
+        TriggerClientEvent('qb-inventory:client:ItemBox', src, itemInfo, 'use')
     end
 end)
 


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

In some instances `source` was dropped by the FiveM scheduler, resulting in error messages whilst still functioning somewhat as intended.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
