### PR TITLE
fix cannot move item between stashes,trunk,glovebox

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -429,7 +429,7 @@ local function getItem(inventoryId, src, slot)
     else
         Inventories[inventoryId]['items']  = transform_input(Inventories[inventoryId]['items'])
         Inventories[inventoryId]['items'] = convert_to_json_array(Inventories[inventoryId]['items'])
-        item = invdata[slot]
+        item = Inventories[inventoryId]['items'][slot]
     end
     return item
 end

--- a/server/main.lua
+++ b/server/main.lua
@@ -376,6 +376,41 @@ QBCore.Functions.CreateCallback('qb-inventory:server:giveItem', function(source,
     cb(true)
 end)
 
+-- Function to convert the JSON object to a JSON array
+local function convert_to_json_array(input)
+    -- Find the maximum slot number
+    local max_slot = 0
+    for _, item in pairs(input) do
+        if item.slot and item.slot > max_slot then
+            max_slot = item.slot
+        end
+    end
+    -- Create the output array with null values for missing slots
+    local output = {}
+    for i = 1, max_slot do
+        output[i] = input[i] or nil
+    end
+    -- Insert the items into their respective slots
+    for _, item in pairs(input) do
+        if item.slot then
+            output[item.slot] = item
+        end
+    end
+    return output
+end
+
+-- Function to transform the input structure to use slot numbers as primary keys
+local function transform_input(input)
+   local transformed = {}
+   for _, item in pairs(input) do
+       local slot = item.slot
+       if slot then
+           transformed[slot] = item
+       end
+   end
+   return transformed
+end
+
 -- Item move logic
 
 local function getItem(inventoryId, src, slot)
@@ -392,7 +427,9 @@ local function getItem(inventoryId, src, slot)
     elseif inventoryId:find('drop-') then
         item = Drops[inventoryId]['items'][slot]
     else
-        item = Inventories[inventoryId]['items'][slot]
+        Inventories[inventoryId]['items']  = transform_input(Inventories[inventoryId]['items'])
+        Inventories[inventoryId]['items'] = convert_to_json_array(Inventories[inventoryId]['items'])
+        item = invdata[slot]
     end
     return item
 end


### PR DESCRIPTION
this pr address and fix the issue in moving item between the player to stashes, trunk and glovebox

## Description

https://cdn.discordapp.com/attachments/1248545472147099729/1248545473887731763/FiveM_by_Cfx.re_-_Nexus_Roleplay_Tamil_2024-06-02_16-21-05.mp4?ex=66695415&is=66680295&hm=80a6549cf7d8770946a105d320b88dcad4fd03a9b1d4915224011fdaba9ce3c0&

This is Pr fixes this issue moving the items caused due to wrong format saved in db

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
