### PR TITLE
Make functions available for non-player inventories (stashes)

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -365,11 +365,6 @@ function CanAddItem(identifier, item, amount)
         items = Inventories[identifier].items
     end
 
-    if not inventory or not items then
-        print("CanAddItem: Inventory not found")
-        return false
-    end
-
     local weight = itemData.weight * amount
     local totalWeight = GetTotalWeight(items) + weight
     if totalWeight > inventory.maxweight then

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -130,13 +130,19 @@ exports('SaveInventory', SaveInventory)
 --- @param items table The items to set in the inventory.
 --- @param reason string The reason for setting the items.
 function SetInventory(identifier, items, reason)
-    if not Inventories[identifier] then return end
     local player = QBCore.Functions.GetPlayer(identifier)
+
+    print('Setting inventory for ' .. identifier)
+
+    if not player and not Inventories[identifier] and not Drops[identifier] then
+        print('SetInventory: Inventory not found')
+        return
+    end
 
     if player then
         player.Functions.SetPlayerData('items', items)
         if not player.Offline then
-            local logMessage = string.format('**%s (citizenid: %s | id: %s)** items set: %s', GetPlayerName(source), player.PlayerData.citizenid, source, json.encode(items))
+            local logMessage = string.format('**%s (citizenid: %s | id: %s)** items set: %s', GetPlayerName(identifier), player.PlayerData.citizenid, identifier, json.encode(items))
             TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'SetInventory', 'blue', logMessage)
         end
     elseif Drops[identifier] then
@@ -345,10 +351,7 @@ exports('GetItemCount', GetItemCount)
 --- @return string|nil - Returns a string indicating the reason why the item cannot be added (e.g., 'weight' or 'slots'), or nil if it can be added.
 function CanAddItem(identifier, item, amount)
 
-    if not Inventories[identifier] then return false end
-
     local Player = QBCore.Functions.GetPlayer(identifier)
-    if not Player then return false end
 
     local itemData = QBCore.Shared.Items[item:lower()]
     if not itemData then return false end
@@ -363,6 +366,11 @@ function CanAddItem(identifier, item, amount)
     elseif Inventories[identifier] then
         inventory = Inventories[identifier]
         items = Inventories[identifier].items
+    end
+
+    if not inventory then
+        print('CanAddItem: Inventory not found')
+        return false
     end
 
     local weight = itemData.weight * amount

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -549,6 +549,19 @@ end
 
 exports('OpenInventory', OpenInventory)
 
+--- Creates a new inventory and returns the inventory object.
+--- @param identifier string The identifier of the inventory to create.
+--- @param data table Additional data for initializing the inventory.
+--- @return table|nil - The inventory object if created successfully, nil otherwise.
+function CreateInventory(identifier, data)
+    if Inventories[identifier] then return end
+    if not identifier then return end
+    Inventories[identifier] = InitializeInventory(identifier, data)
+    return Inventories[identifier]
+end
+
+exports('CreateInventory', CreateInventory)
+
 --- Adds an item to the player's inventory or a specific inventory.
 --- @param identifier string The identifier of the player or inventory.
 --- @param item string The name of the item to add.

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -379,7 +379,7 @@ function CanAddItem(identifier, item, amount)
         return false, 'weight'
     end
 
-    local slotsUsed, slotsFree = GetSlots(identifier)
+    local slotsUsed, _ = GetSlots(identifier)
 
     if slotsUsed >= inventory.slots then
         return false, 'slots'


### PR DESCRIPTION
## Description

Makes a few functions like "CanAddItem" and "SetInventory" usable on stashes
Added: 
    "CreateInventory" - Creates a stash so it can be made ahead of time before using "OpenInventory" for things like adding items
    "GetInventory" - Returns the inventory given via the identifier pram, used to things like checking what items are in a stash
    "RemoveInventory" - Removes a inventory from the "Inventories" table so it wont get saved to the SQL db

Pretty much just functions useful for making and interfacing with stashes for things like custom jobs 

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.