### PR TITLE
Improved getItem inventory matching and fix inventory being stuck

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -389,7 +389,7 @@ local function getItem(inventoryId, src, slot)
         if targetPlayer then
             item = targetPlayer.PlayerData.items[slot]
         end
-    elseif inventoryId:find('drop-') then
+    elseif inventoryId:find('drop-') == 1 then
         item = Drops[inventoryId]['items'][slot]
     else
         item = Inventories[inventoryId]['items'][slot]

--- a/server/main.lua
+++ b/server/main.lua
@@ -116,6 +116,8 @@ AddEventHandler('onResourceStart', function(resourceName)
         QBCore.Functions.AddPlayerMethod(k, 'SetInventory', function(items)
             SetInventory(k, items)
         end)
+
+        Player(k).state.inv_busy = false
     end
 end)
 


### PR DESCRIPTION
## Description
Just two small fixes:
1. Fixed `inventoryId` matching in `getItem`. Without using the character starting index in `find`, names ending with "drop-" couldn't be used (ammoDrop, cargoDrop, etc) and we can't use underscores in names because of how `find` works:
```lua
  -- both of these return the same result
  print(('drop-'):find('drop-'))
  print(('drop_'):find('drop-'))
```
2. Fixed an issue where players could get stuck in `inv_busy = true` state, if they had their inventory open before we restarted the inventory. This one typically is not an issue for most servers, but developers may notice it.
## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
