### PR TITLE
! Refactor: Fix exploit with opening inventory

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -159,15 +159,18 @@ RegisterNetEvent('qb-inventory:server:RobPlayer', function(TargetId)
     })
 end)
 
-RegisterNetEvent('qb-inventory:client:openInventory', function(items, other)
-    SetNuiFocus(true, true)
-    SendNUIMessage({
-        action = 'open',
-        inventory = items,
-        slots = Config.MaxSlots,
-        maxweight = Config.MaxWeight,
-        other = other
-    })
+RegisterNetEvent('qb-inventory:client:openInventory', function(type, name, data)
+    QBCore.Functions.TriggerCallback('qb-inventory:OpenInventory', function(canAccess, items, other)
+        if not canAccess then return end
+        SetNuiFocus(true, true)
+        SendNUIMessage({
+            action = 'open',
+            inventory = items,
+            slots = Config.MaxSlots,
+            maxweight = Config.MaxWeight,
+            other = other
+        })
+    end, type, name, data)
 end)
 
 RegisterNetEvent('qb-inventory:client:giveAnim', function()

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -415,7 +415,7 @@ function CloseInventory(source, identifier)
     if identifier and Inventories[identifier] then
         Inventories[identifier].isOpen = false
     end
-    Player(source).state.inv_busy:set("inv_busy", false, true)
+    Player(source).state:set("inv_busy", false, true)
     TriggerClientEvent('qb-inventory:client:closeInv', source)
 end
 
@@ -496,7 +496,7 @@ function OpenInventory(source, identifier, data)
     if not QBPlayer then return end
 
     if not identifier then
-        Player(source).state.inv_busy:set("inv_busy", true, true)
+        Player(source).state:set("inv_busy", true, true)
         TriggerClientEvent('qb-inventory:client:openInventory', source, "self")
         return
     end


### PR DESCRIPTION
## Description

Fixes exploits that allow players to spawn in any items that they want to.
note, that this is technically a breaking change, due to event param changes

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [x ] My PR fits the contribution guidelines.
