### PR TITLE
Update vehicles.lua

### DIFF
--- a/config/vehicles.lua
+++ b/config/vehicles.lua
@@ -21,13 +21,13 @@ VehicleStorage = {
         gloveboxSlots = 5,
         gloveboxWeight = 10000,
         trunkSlots = 50,
-        maxWeight = 75000
+        trunkWeight = 75000
     },
     [3] = { -- Coupes
         gloveboxSlots = 5,
         gloveboxWeight = 10000,
         trunkSlots = 35,
-        maxWeight = 42000
+        trunkWeight = 42000
     },
     [4] = { -- Muscle
         gloveboxSlots = 5,


### PR DESCRIPTION
Changed line 24 and 30 with trunkWeight instead of maxWeight so it now works for those classes aswell

## Description

The issues is that trunkWeight for Suv and Coupe classes is defined as maxWeight and therefore gets 2000Kg, so when changing it to trunkWeight that its looking for making it work and giving it the correct size and making it changeable again


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
