### PR TITLE
fix checkWeapon function

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -124,11 +124,13 @@ end)
 -- Functions
 
 local function checkWeapon(source, item)
+    local currentWeapon = type(item) == 'table' and item.name or item
     local ped = GetPlayerPed(source)
     local weapon = GetSelectedPedWeapon(ped)
     local weaponInfo = QBCore.Shared.Weapons[weapon]
-    if weaponInfo and weaponInfo.name == item.name then
+    if weaponInfo and weaponInfo.name == currentWeapon then
         RemoveWeaponFromPed(ped, weapon)
+        TriggerClientEvent('qb-weapons:client:UseWeapon', source, { name = currentWeapon }, false)
     end
 end
 


### PR DESCRIPTION
## Description

Fixes issues where giving or dropping a currently equipped weapon does not remove it from your ped, so you can continue to shoot a weapon that you do not posses. 

Issues:
https://github.com/qbcore-framework/qb-inventory/issues/556

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
