### PR TITLE
Fix to bug that permit can buy items even at 0 stock or buy overstock

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -344,6 +344,16 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         end
     end
 
+    if data.item.amount < 1 then
+        TriggerClientEvent('QBCore:Notify', source, 'Out of stock, sorry.', 'error')
+        cb(false)
+        return
+    elseif data.item.amount < amount then
+        TriggerClientEvent('QBCore:Notify', source, 'You cant buy so many units.', 'error')
+        cb(false)
+        return
+    end
+        
     if not CanAddItem(source, itemInfo.name, amount) then
         TriggerClientEvent('QBCore:Notify', source, 'Cannot hold item', 'error')
         cb(false)


### PR DESCRIPTION
Fix to bug that permit can buy items even at 0 stock or buy overstock

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ ] My code fits the style guidelines.
- [ ] My PR fits the contribution guidelines.
