### PR TITLE
Fixed swapping in same inventory checking total weight.

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -447,21 +447,21 @@ const InventoryContainer = Vue.createApp({
                 if (sourceItem.amount < amountToTransfer) {
                     throw new Error("Insufficient amount of item in source inventory");
                 }
-                
-                if (targetInventoryType == "other")
-                    {
+
+                if (targetInventoryType !== this.dragStartInventoryType) {
+                    if (targetInventoryType == "other") {
                         const totalWeightAfterTransfer = this.otherInventoryWeight + sourceItem.weight * amountToTransfer;
                         if (totalWeightAfterTransfer > this.otherInventoryMaxWeight) {
                             throw new Error("Insufficient weight capacity in target inventory");
                         }
                     }
-                else if (targetInventoryType == "player")
-                    {
+                    else if (targetInventoryType == "player") {
                         const totalWeightAfterTransfer = this.playerWeight + sourceItem.weight * amountToTransfer;
                         if (totalWeightAfterTransfer > this.maxWeight) {
                             throw new Error("Insufficient weight capacity in player inventory");
                         }
                     }
+                }
 
                 const targetItem = targetInventory[targetSlotNumber];
 


### PR DESCRIPTION
## Description
Fixed swapping in same inventory checking total weight and showing unwanted warning.
If total weight of player inventory is near to max, then swapping in same inventory was checking `Total weight` + `Swapped Item` weight which is already there in `Total weight`,

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
