### PR TITLE
fix(drops): prevent drop deletion if first slot is nil due to empty indexes

### DIFF
--- a/client/drops.lua
+++ b/client/drops.lua
@@ -1,4 +1,4 @@
-local holdingDrop = false
+holdingDrop = false
 local bagObject = nil
 local heldDrop = nil
 CurrentDrop = nil
@@ -7,24 +7,23 @@ CurrentDrop = nil
 
 function GetDrops()
     QBCore.Functions.TriggerCallback('qb-inventory:server:GetCurrentDrops', function(drops)
-        if drops then
-            for k, v in pairs(drops) do
-                local bag = NetworkGetEntityFromNetworkId(v.entityId)
-                if DoesEntityExist(bag) then
-                    exports['qb-target']:AddTargetEntity(bag, {
-                        options = {
-                            {
-                                icon = 'fas fa-backpack',
-                                label = Lang:t('menu.o_bag'),
-                                action = function()
-                                    TriggerServerEvent('qb-inventory:server:openDrop', k)
-                                    CurrentDrop = dropId
-                                end,
-                            },
+        if not drops then return end
+        for k, v in pairs(drops) do
+            local bag = NetworkGetEntityFromNetworkId(v.entityId)
+            if DoesEntityExist(bag) then
+                exports['qb-target']:AddTargetEntity(bag, {
+                    options = {
+                        {
+                            icon = 'fas fa-backpack',
+                            label = Lang:t('menu.o_bag'),
+                            action = function()
+                                TriggerServerEvent('qb-inventory:server:openDrop', k)
+                                CurrentDrop = k
+                            end,
                         },
-                        distance = 2.5,
-                    })
-                end
+                    },
+                    distance = 2.5,
+                })
             end
         end
     end)
@@ -59,7 +58,7 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
                 label = 'Pick up bag',
                 action = function()
                     if IsPedArmed(PlayerPedId(), 4) then
-                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500) 
+                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500)
                     end
                     if holdingDrop then
                         return QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,4 +1,5 @@
 QBCore = exports['qb-core']:GetCoreObject()
+PlayerData = nil
 local hotbarShown = false
 
 -- Handlers

--- a/server/main.lua
+++ b/server/main.lua
@@ -294,11 +294,18 @@ QBCore.Functions.CreateCallback('qb-inventory:server:createDrop', function(sourc
         local bag = CreateObjectNoOffset(Config.ItemDropObject, playerCoords.x + 0.5, playerCoords.y + 0.5, playerCoords.z, true, true, false)
         local dropId = NetworkGetNetworkIdFromEntity(bag)
         local newDropId = 'drop-' .. dropId
+        local itemsTable = setmetatable({ item }, {
+            __len = function(t)
+                local length = 0
+                for _ in pairs(t) do length += 1 end
+                return length
+            end
+        })
         if not Drops[newDropId] then
             Drops[newDropId] = {
                 name = newDropId,
                 label = 'Drop',
-                items = { item },
+                items = itemsTable,
                 entityId = dropId,
                 createdTime = os.time(),
                 coords = playerCoords,


### PR DESCRIPTION
## Description
This PR changes the items table for drops to overwrite the length operator meaning the table length will be checked appropriately if the index is unordered. This fixes drops being deleted if an item space isn't filled in order.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
