### PR TITLE
fix for opening inventories with data

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -559,9 +559,9 @@ function OpenInventory(source, identifier, data)
     end
 
     if not inventory then inventory = InitializeInventory(identifier, data) end
-    inventory.maxweight = (inventory and inventory.maxweight) or (data and data.maxweight) or Config.StashSize.maxweight
-    inventory.slots = (inventory and inventory.slots) or (data and data.slots) or Config.StashSize.slots
-    inventory.label = (inventory and inventory.label) or (data and data.label) or identifier
+    inventory.maxweight =   (data and data.maxweight) or (inventory and inventory.maxweight) or Config.StashSize.maxweight
+    inventory.slots =       (data and data.slots) or (inventory and inventory.slots) or Config.StashSize.slots
+    inventory.label =       (data and data.label) or (inventory and inventory.label)  or identifier
     inventory.isOpen = source
 
     local formattedInventory = {


### PR DESCRIPTION
## Description
Currently: You can create a stash named anything you want. set it to 5 slots and 2000 max pounds. If you were to adjust this to 10 slots and 1000 pounds it will retain its original set data and not take the new data being sent

This: It moves the data check to the beginning so if its nil then it goes to previous data check. this will allow people to not have to recreate stashes to adjust settings of it. and if its the first time opening that stash with no data being sent then it goes to config values

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x ] My code fits the style guidelines.
- [ x] My PR fits the contribution guidelines.
