### PR TITLE
Make AddItem work with non-intitalised vehicle inventories

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -598,11 +598,9 @@ function AddItem(identifier, item, amount, slot, info, reason, vehicleClass)
     local player = QBCore.Functions.GetPlayer(identifier)
 
     local vehicle = nil
-    for word in string.gmatch(identifier, "([^%-]+)") do
-        if word == "trunk" or word == "glovebox" then
-            vehicle = word
-            break
-        end
+    local word = QBCore.Shared.SplitStr(item, '-')[1]
+    if word == "trunk" or word == "glovebox" then
+        vehicle = word
     end
     if player then
         inventory = player.PlayerData.items

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -673,13 +673,15 @@ function AddItem(identifier, item, amount, slot, info, reason, vehicleClass)
     local player = QBCore.Functions.GetPlayer(identifier)
 
     local vehicle = nil
-    local word = QBCore.Shared.SplitStr(item, '-')[2]
+    local word = QBCore.Shared.SplitStr(identifier, '-')[1]
     if word == "trunk" or word == "glovebox" then
         vehicle = word
     end
     if player then
+        local src = player.PlayerData.source
         inventory = player.PlayerData.items
-        inventoryWeight = Config.MaxWeight
+        local value = exports["dw_skillsystem"]:GetSkillValue(src, "maxWeight")
+        inventoryWeight = Config.MaxWeight * value
         inventorySlots = Config.MaxSlots
     elseif Inventories[identifier] then
         inventory = Inventories[identifier].items
@@ -692,6 +694,7 @@ function AddItem(identifier, item, amount, slot, info, reason, vehicleClass)
     elseif vehicle then  
         Inventories[identifier] = {}
         Inventories[identifier].items = {}
+        inventory = Inventories[identifier].items
         local storageConfig = VehicleStorage[vehicleClass] or VehicleStorage.default
         if vehicle == "trunk" then 
             Inventories[identifier].maxweight = storageConfig.trunkWeight

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -598,7 +598,7 @@ function AddItem(identifier, item, amount, slot, info, reason, vehicleClass)
     local player = QBCore.Functions.GetPlayer(identifier)
 
     local vehicle = nil
-    local word = QBCore.Shared.SplitStr(item, '-')[1]
+    local word = QBCore.Shared.SplitStr(item, '-')[2]
     if word == "trunk" or word == "glovebox" then
         vehicle = word
     end


### PR DESCRIPTION
## Description
I had an issue where I couldn't add items to the trunk of my delivery van for my postal job because the trunk didn't exist, so I wrote an extension to AddItem for this case. The only change a developer needs to make is the vehicleClass to the end of the export[there's no server side native for it :( ].

Usage examples:      
`exports['qb-inventory']:AddItem(identifier, itemName, amount, slot,  info, reason, vehicleClass) 
`
`exports['qb-inventory']:AddItem("trunk-" .. plate, "package", 1, false, info, "postaljob", 12) 
`

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ Yes] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ Yes ] My code fits the style guidelines.
- [ Yes] My PR fits the contribution guidelines.
