### PR TITLE
Update vehicles.lua

### DIFF
--- a/client/vehicles.lua
+++ b/client/vehicles.lua
@@ -36,7 +36,7 @@ QBCore.Functions.CreateClientCallback('qb-inventory:client:vehicleCheck', functi
     if inVehicle ~= 0 then
         local plate = GetVehicleNumberPlateText(inVehicle)
         local class = GetVehicleClass(inVehicle)
-        local inventory = 'glovebox-' .. plate
+        local inventory = 'glovebox-' .. plate:gsub("%s+", "")
         cb(inventory, class)
         return
     end
@@ -53,7 +53,7 @@ QBCore.Functions.CreateClientCallback('qb-inventory:client:vehicleCheck', functi
                 OpenTrunk(vehicle)
                 local class = GetVehicleClass(vehicle)
                 local plate = GetVehicleNumberPlateText(vehicle)
-                local inventory = 'trunk-' .. plate
+                local inventory = 'trunk-' .. plate:gsub("%s+", "")
                 cb(inventory, class)
             else
                 QBCore.Functions.Notify(Lang:t('notify.vlocked'), 'error')


### PR DESCRIPTION
Fix spaces in GetVehicleNumberPlateText

## Description

This fixes an issue with trunks.
When fetching with GetVehicleNumberPlateText it adds a space when the plate is shorter then 8 characters:

![image](https://github.com/user-attachments/assets/827b2967-058f-4cf8-90f1-5d2da65de395)

Added gsub to trim whitespaces out and the outcome is without spaces:

![image](https://github.com/user-attachments/assets/e1a84489-71ad-4a87-9211-ea76bbd587ae)

This will fix issues when adding items to trunk where it can't match the plate numbers because the actual plate is without spaces.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [X ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [X ] My code fits the style guidelines.
- [X ] My PR fits the contribution guidelines.
