### PR TITLE
Add inventory to cache on creating custom one from other resources.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -522,3 +522,11 @@ RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory,
         end
     end
 end)
+
+-- Event to add the custom inventory created to Inventory cache.
+RegisterNetEvent('qb-inventory:server:addInventoryToCache', function(invId, inventoryData)
+    Inventories[invId] = {
+        isOpen = false,
+        items = inventoryData
+    }
+end)


### PR DESCRIPTION
## Description
If someone try to create a custom inventory other than stash, glovebox, shop it is currently impossible to add the inventory to existing server inventory cache.
Created a new event to add the new inventory to the `Inventories` cache in server/main.lua file.

Usage in server scripts:
```
RegisterNetEvent("qb-lockers:openInventory", function(lockerId)
    local src = source
    local InventoryItems = {}
    local lockerInventory = exports["qb-inventory"]:GetInventory(lockerId)
	if (lockerInventory ) then
         InventoryItems = lockerInventory.items
	end
    TriggerEvent("qb-inventory:server:addInventoryToCache", lockerId, InventoryItems )
    exports["qb-inventory"]:OpenInventory(src, lockerId)
end)
```

This method allows us to add a new inventory, such as [QB Lockers](https://github.com/adhershmnair/qb-lockers/blob/main/server/main.lua#L136-L145), which is a custom inventory, and open it immediately after creating it.
Note: Adding the inventory to the database will be handled within the custom inventory's resource.

![image](https://github.com/user-attachments/assets/af9db568-e0a5-4f0d-a8cd-a3cd58333353)
