### PR TITLE
fix(server/functions): handle nil player names and fallback to citizenid

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -84,7 +84,7 @@ function LoadInventory(source, citizenid)
     end
 
     if #missingItems > 0 then
-        print(('The following items were removed for player %s as they no longer exist: %s'):format(GetPlayerName(source), table.concat(missingItems, ', ')))
+        print(('The following items were removed for player %s as they no longer exist: %s'):format(source and GetPlayerName(source) or citizenid, table.concat(missingItems, ', ')))
     end
 
     return loadedInventory


### PR DESCRIPTION
## Description
I've been having several clients reporting that qb-inventory was giving an error when using the LoadInventory export with offline players that had items that didn't exist, my script uses a lot of functions related to offline players and I've been getting the same problem several times, I've made it so that if the source is not defined the citizenid is used.

## More Info
Screenshot of the error some customers send to me:
![image](https://github.com/user-attachments/assets/560c1b69-5fe6-4e8a-af9d-c14895646e2e)


## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
