### PR TITLE
Fixed equipped weapon not removing from the player hand on clear inventory.

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -432,7 +432,7 @@ function ClearInventory(source, filterItems)
         TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'ClearInventory', 'red', logMessage)
         local ped = GetPlayerPed(source)
         local weapon = GetSelectedPedWeapon(ped)
-        if weapon ~= GetHashKey('WEAPON_UNARMED') then
+        if weapon ~= `WEAPON_UNARMED` then
             RemoveWeaponFromPed(ped, weapon)
         end
         if Player(source).state.inv_busy then TriggerClientEvent('qb-inventory:client:updateInventory', source) end

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -430,6 +430,11 @@ function ClearInventory(source, filterItems)
     if not player.Offline then
         local logMessage = string.format('**%s (citizenid: %s | id: %s)** inventory cleared', GetPlayerName(source), player.PlayerData.citizenid, source)
         TriggerEvent('qb-log:server:CreateLog', 'playerinventory', 'ClearInventory', 'red', logMessage)
+        local ped = GetPlayerPed(source)
+        local weapon = GetSelectedPedWeapon(ped)
+        if weapon ~= GetHashKey('WEAPON_UNARMED') then
+            RemoveWeaponFromPed(ped, weapon)
+        end
         if Player(source).state.inv_busy then TriggerClientEvent('qb-inventory:client:updateInventory', source) end
     end
 end


### PR DESCRIPTION
## Description
[Equipped weapon doesn't remove from player's hand when inventory cleared.](https://github.com/qbcore-framework/qb-inventory/issues/586#issuecomment-2496246066)


<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
