### PR TITLE
🐛 Purchase larger amount than stocked

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -351,6 +351,12 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         end
     end
 
+    if amount > itemInfo.amount then
+        TriggerClientEvent('QBCore:Notify', source, 'Cannot purchase larger quantity than currently in stock', 'error')
+        cb(false)
+        return
+    end
+
     if not CanAddItem(source, itemInfo.name, amount) then
         TriggerClientEvent('QBCore:Notify', source, 'Cannot hold item', 'error')
         cb(false)

--- a/server/main.lua
+++ b/server/main.lua
@@ -351,7 +351,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         end
     end
 
-    if amount > itemInfo.amount then
+    if amount > shopInfo.items[itemInfo.slot].amount then
         TriggerClientEvent('QBCore:Notify', source, 'Cannot purchase larger quantity than currently in stock', 'error')
         cb(false)
         return


### PR DESCRIPTION
## Description

This PR fixes a bug addressed in the following issue: https://github.com/qbcore-framework/qb-inventory/issues/595

The bug comes from a simple oversight in the [attemptPurchase](https://github.com/qbcore-framework/qb-inventory/blob/05bac43c30aa02ce1cb3443bb2b81577ea246c5a/server/main.lua#L326-L369) callback, where the amount that the player selected and the actual current stock in the store are not compared/tested. I have added the beforementioned check and the issue is now gone.

I have tested the change/fix locally, by following the steps for reproduction in the inital report/issue before and after the fix.

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
