### PR TITLE
fix: item purchasing spawn exploit

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -351,6 +351,11 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         end
     end
 
+    if shopInfo.items[itemInfo.slot].name ~= itemInfo.name then -- Check if item name passed is the same as the item in that slot
+        cb(false)
+        return
+    end
+
     if amount > shopInfo.items[itemInfo.slot].amount then
         TriggerClientEvent('QBCore:Notify', source, 'Cannot purchase larger quantity than currently in stock', 'error')
         cb(false)

--- a/server/main.lua
+++ b/server/main.lua
@@ -327,7 +327,6 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
     local itemInfo = data.item
     local amount = data.amount
     local shop = string.gsub(data.shop, 'shop%-', '')
-    local price = itemInfo.price * amount
     local Player = QBCore.Functions.GetPlayer(source)
 
     if not Player then
@@ -368,6 +367,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         return
     end
 
+    local price = shopInfo.items[itemInfo.slot].price * amount
     if Player.PlayerData.money.cash >= price then
         Player.Functions.RemoveMoney('cash', price, 'shop-purchase')
         AddItem(source, itemInfo.name, amount, nil, itemInfo.info, 'shop-purchase')


### PR DESCRIPTION
## Description
This PR fixes an exploit that allows a client to spawn items without the appropriate checks and validation.
To perform this validation, it uses the data given by qb-shops handle checks like checking if the slot given by the client is the same as the slot given by the shop, and rather than using the price given by the client, instead use the price given by the shop.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
