### PR TITLE
weapon check convention

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -745,7 +745,7 @@ function AddItem(identifier, item, amount, slot, info, reason)
             combinable = itemInfo.combinable
         }
 
-        if QBCore.Shared.SplitStr(item, '_')[1] == 'weapon' then
+        if itemInfo.type == 'weapon' then
             if not inventory[slot].info.serie then
                 inventory[slot].info.serie = tostring(QBCore.Shared.RandomInt(2) .. QBCore.Shared.RandomStr(3) .. QBCore.Shared.RandomInt(1) .. QBCore.Shared.RandomStr(2) .. QBCore.Shared.RandomInt(3) .. QBCore.Shared.RandomStr(4))
             end


### PR DESCRIPTION
any item even if not weapon containing weapon_ receives serial and quality, also any weapons not containing weapon_ don't receive quality

## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->

any item even if not weapon containing weapon_ receives serial and quality, also any weapons not containing weapon_ don't receive quality

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [ x ] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [ x ] My code fits the style guidelines.
- [ x ] My PR fits the contribution guidelines.
