### PR TITLE
Tab to close or escape

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -907,12 +907,10 @@ const InventoryContainer = Vue.createApp({
     mounted() {
         window.addEventListener("keydown", (event) => {
             const key = event.key;
-            if (key === "Escape") {
+            if (key === "Escape" || key === "Tab") {
                 if (this.isInventoryOpen) {
                     this.closeInventory();
                 }
-            } else if (key === "Tab") {
-                event.preventDefault();
             }
         });
 


### PR DESCRIPTION
## Description

This pull request adds the functionality for adding tab to closing the inventory aswell as escape. Making both close the inventory makes sense in my opinion, especially since it was the old keybind.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
