### PR TITLE
fix: checkWeapon when RemoveItem

### DIFF
--- a/server/functions.lua
+++ b/server/functions.lua
@@ -855,7 +855,14 @@ function RemoveItem(identifier, item, amount, slot, reason)
         inventory[itemKey] = inventoryItem
     end
 
-    if player then player.Functions.SetPlayerData('items', inventory) end
+    if player then 
+        player.Functions.SetPlayerData('items', inventory)
+        
+        local itemInfo = QBCore.Shared.Items[item:lower()]
+        if itemInfo and itemInfo.type == 'weapon' and inventoryItem.amount <= 0 then
+            checkWeapon(identifier, item)
+        end
+    end
 
     local invName = player and GetPlayerName(identifier) .. ' (' .. identifier .. ')' or identifier
     local removeReason = reason or 'No reason specified'

--- a/server/functions.lua
+++ b/server/functions.lua
@@ -855,7 +855,7 @@ function RemoveItem(identifier, item, amount, slot, reason)
         inventory[itemKey] = inventoryItem
     end
 
-    if player then 
+    if player then
         player.Functions.SetPlayerData('items', inventory)
         
         local itemInfo = QBCore.Shared.Items[item:lower()]

--- a/server/main.lua
+++ b/server/main.lua
@@ -123,7 +123,7 @@ end)
 
 -- Functions
 
-local function checkWeapon(source, item)
+function checkWeapon(source, item)
     local currentWeapon = type(item) == 'table' and item.name or item
     local ped = GetPlayerPed(source)
     local weapon = GetSelectedPedWeapon(ped)


### PR DESCRIPTION
## Description

Fixed the issue where equipped weapons could still be used when removing weapons with RemoveItem export

## Checklist

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
