### PR TITLE
fix: Duplication

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -491,7 +491,7 @@ end
 
 RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory, toInventory, fromSlot, toSlot, fromAmount, toAmount)
     if toInventory:find('shop%-') then return end
-    if not fromInventory or not toInventory or not fromSlot or not toSlot or not fromAmount or not toAmount then return end
+    if not fromInventory or not toInventory or not fromSlot or not toSlot or not fromAmount or not toAmount or fromAmount < 0 or toAmount < 0 then return end
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end


### PR DESCRIPTION
## Description
Fixed a duplication glitch where calling SetInventoryData via NUI dev tools with a negative value of either fromAmount or toAmount would result in a duplication of the item.

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
