### PR TITLE
Adding multiple item boxes support

### DIFF
--- a/html/app.js
+++ b/html/app.js
@@ -785,13 +785,14 @@ const InventoryContainer = Vue.createApp({
             
             if (existingIndex > -1) {
                 // Update existing notification amount
-                this.notifications[existingIndex].amount += notification.amount;
-                this.notifications[existingIndex].timestamp = Date.now();
+                const existingNotification = this.notifications[existingIndex];
+                existingNotification.amount += notification.amount;
+                existingNotification.timestamp = Date.now();
                 
                 // Reset the timeout for the existing notification
-                clearTimeout(this.notifications[existingIndex].timeoutId);
-                this.notifications[existingIndex].timeoutId = setTimeout(() => {
-                    this.removeNotification(this.notifications[existingIndex].id);
+                clearTimeout(existingNotification.timeoutId);
+                existingNotification.timeoutId = setTimeout(() => {
+                    this.removeNotification(existingNotification.id);
                 }, 3000);
             } else {
                 // Add new notification
@@ -812,8 +813,9 @@ const InventoryContainer = Vue.createApp({
             const index = this.notifications.findIndex(n => n.id === notificationId);
             if (index > -1) {
                 // Clear timeout if it exists
-                if (this.notifications[index].timeoutId) {
-                    clearTimeout(this.notifications[index].timeoutId);
+                const timeoutId = this.notifications[index].timeoutId;
+                if (timeoutId) {
+                    clearTimeout(timeoutId);
                 }
                 this.notifications.splice(index, 1);
             }

--- a/html/index.html
+++ b/html/index.html
@@ -152,19 +152,33 @@
                     </div>
                 </div>
             </div>
-            <div class="notification-container" v-if="showNotification">
-                <div class="notification-slot">
-                    <div class="notification-title">
-                        <p>{{ notificationType }}</p>
-                    </div>
-                    <div class="item-slot-img">
-                        <img :src="notificationImage" alt="" />
-                    </div>
-                    <div class="item-slot-amount">
-                        <p>x{{ notificationAmount }}</p>
-                    </div>
-                    <div class="item-slot-label">
-                        <p>{{ notificationText }}</p>
+            <!-- Multiple Notifications Container -->
+            <div class="notifications-container" v-if="notifications.length > 0">
+                <div 
+                    v-for="(notification, index) in notifications" 
+                    :key="notification.id" 
+                    class="notification-item"
+                    :style="{ 
+                        'z-index': 1000 + index,
+                        'opacity': 1
+                    }"
+                    @click="removeNotification(notification.id)"
+                    title="Click to dismiss"
+                >
+                    <div class="notification-slot">
+                        <div class="notification-close">×</div>
+                        <div class="notification-title">
+                            <p>{{ notification.type }}</p>
+                        </div>
+                        <div class="item-slot-img">
+                            <img :src="notification.image" alt="" />
+                        </div>
+                        <div class="item-slot-amount">
+                            <p>x{{ notification.amount }}</p>
+                        </div>
+                        <div class="item-slot-label">
+                            <p>{{ notification.text }}</p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/html/main.css
+++ b/html/main.css
@@ -333,6 +333,96 @@ div {
     transform: translate(-50%);
 }
 
+/* Multiple Notifications Container */
+.notifications-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    bottom: 2vh;
+    left: 50%;
+    transform: translateX(-50%);
+    gap: 1vh;
+    flex-wrap: wrap;
+}
+
+.notification-item {
+    position: relative;
+    transition: all 0.3s ease;
+    animation: slideInUp 0.3s ease-out;
+    margin: 0 0.5vh;
+    flex-shrink: 0;
+}
+
+@keyframes slideInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px) scale(0.8);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.notification-item {
+    cursor: pointer;
+}
+
+.notification-item:hover {
+    transform: scale(1.02);
+    filter: brightness(1.1);
+}
+
+.notification-item:active {
+    transform: scale(0.98);
+}
+
+/* Fade out animation for removal */
+.notification-item.removing {
+    animation: fadeOut 0.3s ease-in forwards;
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+    to {
+        opacity: 0;
+        transform: translateY(-20px);
+    }
+}
+
+/* Close button styling */
+.notification-close {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 16px;
+    height: 16px;
+    background-color: rgba(0, 0, 0, 0.5);
+    color: white;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: bold;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    z-index: 10;
+}
+
+.notification-item:hover .notification-close {
+    opacity: 1;
+}
+
+.notification-close:hover {
+    background-color: rgba(255, 0, 0, 0.7);
+}
+
 .notification-slot {
     position: relative;
     width: 10vh;


### PR DESCRIPTION
Itembox notifications can show in a row of up to 5 notifications at once

Normally if it receives 2 or more removal or add events of different items it will only show 1 item box notification instead of all

## Checklist
- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
